### PR TITLE
Keep .Rproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .Rhistory
 .RData
 inst/doc
-janitor.Rproj


### PR DESCRIPTION
It seems to be common practice to include a .Rproj file (e.g., among many, https://github.com/ropenscilabs/assertr). This would make it a little quicker to jump into development and would ensure that we are, for example, using the same number of spaces for tabs. 