### PR TITLE
address breaking change in dplyr 0.6.0 affecting tabyl()

### DIFF
--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -59,7 +59,12 @@ tabyl.default <- function(vec, sort = FALSE, show_na = TRUE, ...) {
     result <- dat %>% dplyr::count(vec, sort = sort)
     
     if(is.factor(vec)){
-      result <- tidyr::complete(result, vec)
+      expanded <- tidyr::expand(result, vec)
+      result <- merge(x = expanded, # can't use dplyr::left_join because as of 0.6.0, NAs don't match, and na_matches argument not present < 0.6.0
+                      y = result,
+                      by = "vec",
+                      all.x = TRUE)
+      result <- dplyr::arrange(result, vec) # restore sorting by factor level
       if(sort){result <- dplyr::arrange(result, dplyr::desc(n))} # undo reorder caused by complete()
     }
     

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -37,7 +37,7 @@ test_that("show_NA = FALSE parameter works", {
                tabyl(test_df_na$grp, show_na = FALSE))
 })
 
-test_that("sorting is preserved for factors", {
+test_that("ordering of result by factor levels is preserved for factors", {
   expect_equal(tabyl(factor(c("x", "y", "z"), levels = c("y", "z", "x")))[[1]], factor(c("y", "z", "x"), levels = c("y", "z", "x")))
 })
 


### PR DESCRIPTION
`tidyr::complete()` calls `dplyr::left_join()` and this will [no longer](https://github.com/tidyverse/dplyr/releases/tag/v0.6.0-rc) match `NA` values the same way, which tabyl depended on:

> 
> [API] xxx_join.tbl_df() by default treats all NA values as
> different from each other (and from any other value), so that they never
> match. This corresponds to the behavior of joins for database sources,
> and of database joins in general. To match NA values, pass
> na_matches = "na" to the join verbs; this is only supported for data frames.
> The default can also be tweaked by calling
> pkgconfig::set_config("dplyr::na_matches", "na") 

Since `complete` was a wrapper anyway, I expanded it (no pun intended) and used `merge` instead of `left_join`.
 
Closes #111