### PR TITLE
introduce print.tabyl to suppress printing of tabyl row numbers

### DIFF
--- a/R/as_and_untabyl.R
+++ b/R/as_and_untabyl.R
@@ -63,7 +63,3 @@ untabyl <- function(dat){
   attr(dat, "tabyl_type") <- NULL # may not exist, but simpler to declare it NULL regardless than to check to see if it exists
   dat
 }
-
-print.tabyl <- function(x){
-  print.data.frame(x, row.names = FALSE)
-}

--- a/R/as_and_untabyl.R
+++ b/R/as_and_untabyl.R
@@ -36,7 +36,7 @@ as_tabyl <- function(dat, axes = 2){
     axes == 1 ~ "one_way",
     axes == 2 ~ "two_way"
   )
-  class(dat) <- c(class(dat), "tabyl")
+  class(dat) <- c("tabyl", class(dat))
   dat
 }
 
@@ -62,4 +62,8 @@ untabyl <- function(dat){
   attr(dat, "totals") <- NULL # may not exist, but simpler to declare it NULL regardless than to check to see if it exists
   attr(dat, "tabyl_type") <- NULL # may not exist, but simpler to declare it NULL regardless than to check to see if it exists
   dat
+}
+
+print.tabyl <- function(x){
+  print.data.frame(x, row.names = FALSE)
 }

--- a/R/print_tabyl.R
+++ b/R/print_tabyl.R
@@ -1,0 +1,3 @@
+print.tabyl <- function(x){
+  print.data.frame(x, row.names = FALSE)
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,5 @@ comment:
   require_base: no        # [yes :: must have a base report to post]
   require_head: yes       # [yes :: must have a head report to post]
   branches: null
+  ignore:
+  - "print_*"

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -171,13 +171,13 @@ test_that("works with non-numeric columns mixed in; fill character specification
 test_that("totals attributes are assigned correctly", {
   post <- adorn_totals(ct, c("row", "col"))
   expect_equal(attr(post, "totals"), c("row", "col"))
-  expect_equal(class(post), c("data.frame", "tabyl"))
+  expect_equal(class(post), c("tabyl", "data.frame"))
   expect_equal(attr(post, "tabyl_type"), "two_way")
   expect_equal(attr(post, "core"), untabyl(ct))
   
   post_col <- adorn_totals(ct, "col")
   expect_equal(attr(post_col, "totals"), "col")
-  expect_equal(class(post_col), c("data.frame", "tabyl"))
+  expect_equal(class(post_col), c("tabyl", "data.frame"))
   expect_equal(attr(post_col, "tabyl_type"), "two_way")
   expect_equal(attr(post_col, "core"), untabyl(ct))
 })

--- a/tests/testthat/test-crosstab.R
+++ b/tests/testthat/test-crosstab.R
@@ -57,7 +57,7 @@ test_that("percentages are correct", {
   expect_equal(res_col[[4]], c(1/3, 1/3, 1/3))
 
   res_all <- suppressWarnings(crosstab(dat$v2, dat$v4, "all"))
-  expect_equal(untabyl(as.data.frame(res_all[, 2:4])), as.data.frame(res[, 2:4]/9))
+  expect_equal(as.data.frame(res_all[, 2:4]), res[, 2:4]/9)
 })
 
 z <- suppressWarnings(crosstab(dat$v3, dat$v1))
@@ -110,7 +110,7 @@ test_that("crosstab.data.frame renders percentages are correct", {
   expect_equal(res_col[[4]], c(1/3, 1/3, 1/3))
 
   res_all <- suppressWarnings(crosstab(dat, v2, v4, "all"))
-  expect_equal(untabyl(as.data.frame(res_all[, 2:4])), as.data.frame(res[, 2:4]/9))
+  expect_equal(untabyl(res_all[, 2:4]), res[, 2:4]/9)
 })
 
 test_that("bad input variable name is preserved", {


### PR DESCRIPTION
reorders classes of tabyl to put tabyl before data.frame.  Implements #141