### PR TITLE
Show NA_ level in list from 3-way tabyl, handle all-NA and zero length inputs to 2-way tabyl

### DIFF
--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -177,7 +177,6 @@ tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TR
     levels(tabl[[2]]) <- c(levels(tabl[[2]]), "NA_")
   }
   tabl[2][is.na(tabl[2])] <- "NA_"
-  
   result <- tabl %>%
     tidyr::spread_(rlang::quo_name(var2), "n", fill = 0)
   
@@ -195,8 +194,10 @@ tabyl_3way <- function(dat, var1, var2, var3, show_na = TRUE, show_missing_level
   dat[[3]] <- as.character(dat[[3]]) # don't want empty factor levels in the result list - they would be empty data.frames
   
   # print NA level as its own data.frame, and make it appear last
-  dat[[3]] <- factor(dat[[3]], levels = c(sort(unique(dat[[3]])), "NA_"))
-  dat[[3]][is.na(dat[[3]])] <- "NA_"
+  if(sum(is.na(dat[[3]])) > 0){
+    dat[[3]] <- factor(dat[[3]], levels = c(sort(unique(dat[[3]])), "NA_"))
+    dat[[3]][is.na(dat[[3]])] <- "NA_"
+  }
   
   if(!show_missing_levels){ # this shows missing factor levels, to make the crosstabs consistent across each data.frame in the list based on values of var3
     if(is.factor(dat[[1]])){ dat[[1]] <- as.character(dat[[1]]) }

--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -160,10 +160,16 @@ tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TR
   if(!show_na){
     dat <- dat[!is.na(dat[[1]]) & !is.na(dat[[2]]), ]
   }
+   if(nrow(dat) == 0){ # if passed a zero-length input, or an entirely NA input, return a zero-row data.frame
+     message("No records to count so returning a zero-row tabyl")
+     return(dat %>%
+              dplyr::select(1) %>%
+              dplyr::slice(0))
+   }
   
   tabl <- dat %>%
     dplyr::count(!! var1, !! var2)
-  
+
   # Optionally expand missing factor levels.
   if(show_missing_levels){
     combos <- tidyr::complete_(tabl %>% dplyr::select(-n), names(tabl)[1:2]) # this is pretty ugly - using dplyr keeps col types the same making for easier join, vs. expand.grid
@@ -206,6 +212,7 @@ tabyl_3way <- function(dat, var1, var2, var3, show_na = TRUE, show_missing_level
     dat[[1]] <- as.factor(dat[[1]])
     dat[[2]] <- as.factor(dat[[2]])
   }
+  
   split(dat, dat[[rlang::quo_name(var3)]]) %>%
     purrr::map(tabyl_2way, var1, var2, show_na = show_na, show_missing_levels = show_missing_levels)
 }

--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -193,10 +193,14 @@ tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TR
 tabyl_3way <- function(dat, var1, var2, var3, show_na = TRUE, show_missing_levels = TRUE){
   dat <- dplyr::select(dat, !! var1, !! var2, !! var3)
   dat[[3]] <- as.character(dat[[3]]) # don't want empty factor levels in the result list - they would be empty data.frames
-
+  
+  # print NA level as its own data.frame, and make it appear last
+  dat[[3]] <- factor(dat[[3]], levels = c(sort(unique(dat[[3]])), "NA_"))
+  dat[[3]][is.na(dat[[3]])] <- "NA_"
+  
   if(!show_missing_levels){ # this shows missing factor levels, to make the crosstabs consistent across each data.frame in the list based on values of var3
-    dat[[1]] <- as.character(dat[[1]])
-    dat[[2]] <- as.character(dat[[2]])
+    if(is.factor(dat[[1]])){ dat[[1]] <- as.character(dat[[1]]) }
+    if(is.factor(dat[[2]])){ dat[[2]] <- as.character(dat[[2]]) }
   } else {
     dat[[1]] <- as.factor(dat[[1]])
     dat[[2]] <- as.factor(dat[[2]])

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -228,6 +228,16 @@ test_that("NA levels get moved to the last column in the data.frame, are suppres
   expect_equal(y_with_missing[["NA_"]] %>% untabyl(), # here c column is factor b/c show_missing_levels = TRUE
                data.frame(c = "10", `1` = 1, `2` = 0, NA_ = 1, check.names = FALSE))
   
+  # If no NA in 3rd variable, it doesn't appear in split list
+  expect_equal(length(starwars %>%
+                        filter(species == "Human") %>%
+                        tabyl(eye_color, skin_color, gender, show_missing_levels = TRUE)), 2)
+  
+  # If there is NA, it does appear in split list
+  expect_equal(length(starwars %>%
+                        tabyl(eye_color, skin_color, gender, show_missing_levels = TRUE)), 5)
+  expect_equal(length(starwars %>%
+                        tabyl(eye_color, skin_color, gender, show_missing_levels = FALSE)), 5)
 })
 
 test_that("print.tabyl prints without row numbers", {

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -185,6 +185,7 @@ expect_equal(mtcars %>% tabyl(cyl, am),
 test_that("NA levels get moved to the last column in the data.frame, are suppressed properly", {
   x <- data.frame(a = c(1, 2, 2, 2, 1, 1, 1, NA, NA, 1),
                   b = c(rep("up", 4), rep("down", 4), NA, NA),
+                  c = 10,
   stringsAsFactors = FALSE)
   y <- tabyl(x, a, b) %>%
     untabyl()
@@ -213,6 +214,20 @@ test_that("NA levels get moved to the last column in the data.frame, are suppres
       check.names = FALSE
     )
   )
+  
+  # NA level is shown in 3 way split
+  y <- x %>% tabyl(c, a, b, show_missing_levels = FALSE)
+  expect_equal(length(y), 3)
+  expect_equal(names(y), c("down", "up", "NA_"))
+  expect_equal(y[["NA_"]], # here the c column is numeric because show_missing_levels = FALSE
+               x %>% filter(is.na(b)) %>% tabyl(c, a))
+  
+  y_with_missing <- x %>% tabyl(c, a, b, show_missing_levels = TRUE)
+  expect_equal(length(y_with_missing), 3)
+  expect_equal(names(y_with_missing), c("down", "up", "NA_"))
+  expect_equal(y_with_missing[["NA_"]] %>% untabyl(), # here c column is factor b/c show_missing_levels = TRUE
+               data.frame(c = "10", `1` = 1, `2` = 0, NA_ = 1, check.names = FALSE))
+  
 })
 
 test_that("print.tabyl prints without row numbers", {

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -240,6 +240,22 @@ test_that("NA levels get moved to the last column in the data.frame, are suppres
                         tabyl(eye_color, skin_color, gender, show_missing_levels = FALSE)), 5)
 })
 
+test_that("zero-row and fully-NA inputs are handled", {
+  zero_vec <- character(0)
+  expect_equal(nrow(tabyl(zero_vec)), 0) 
+  expect_equal(names(tabyl(zero_vec)), c("zero_vec", "n", "percent"))
+  
+  zero_df <- data.frame(a = character(0), b = character(0))
+  expect_equal(nrow(tabyl(zero_df, a, b)), 0)
+  expect_equal(names(tabyl(zero_df, a, b)), "a")
+  expect_message(tabyl(zero_df, a, b), "No records to count so returning a zero-row tabyl")
+  
+  all_na_df <- data.frame(a = c(NA, NA), b = c(NA_character_, NA_character_))
+  expect_equal(tabyl(all_na_df, a, b, show_na = FALSE) %>% nrow, 0)
+  expect_equal(tabyl(all_na_df, a, b, show_na = FALSE) %>% names, "a")
+  expect_message(tabyl(all_na_df, a, b, show_na = FALSE), "No records to count so returning a zero-row tabyl")
+})
+
 test_that("print.tabyl prints without row numbers", {
   expect_equal(
     mtcars %>% tabyl(am, cyl) %>% capture.output(),


### PR DESCRIPTION
Addresses #167, #166.  The introduction of `is.factor()` test below is a precursor to addressing #168:

```
if(!show_missing_levels){ # this shows missing factor levels, to make the crosstabs consistent across each data.frame in the list based on values of var3
    if(is.factor(dat[[1]])){ dat[[1]] <- as.character(dat[[1]]) }
    if(is.factor(dat[[2]])){ dat[[2]] <- as.character(dat[[2]]) }
  }
```
Doesn't come close to fully addressing #168, but is a step in that direction.  Since it's mildly helpful on its own (now numerics won't be unnecessarily coerced to factors), leaving it in.