### PR TITLE
clean_names respects separators (or lack) between number and letter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: packages
 
 before_install:
   Rscript -e 'update.packages(ask = FALSE)'
-  
+
 matrix: # don't test osx + r-devel
   include:
   - os: linux
@@ -24,6 +24,7 @@ matrix: # don't test osx + r-devel
 
 r_github_packages:
   - jimhester/covr
+  - tazinho/snakecase
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@ The legacy functions `crosstab` and `adorn_crosstab` have been deprecated, but r
 
 ### Breaking improvements to `clean_names`
 
-`clean_names()` now detects and preserves camelCase inputs and allows multiple options for case outputs of the cleaned data.frame.  It also converts accented letters and turns `#` into `"number"`.  This is a breaking change, e.g., `variableName` in the data is now converted to `variable_name` (or `variableName`, `VariableName`, etc. depending on your preference).  This may cause old code to break, where it would have been `variablename`.  To minimize this inconvenience, there's a quick fix for compatibility: you can find-and-replace to insert the argument `case = "old_janitor"` to preserve the old behavior of `clean_names()` as of version 0.3.0 (and thus not have to redo your scripts beyond that.)
+`clean_names()` now detects and preserves camelCase inputs and allows multiple options for case outputs of the cleaned data.frame.  It also converts accented letters and turns `#` into `"number"`.  This is a breaking change, e.g., `variableName` in the data is now converted to `variable_name` (or `variableName`, `VariableName`, etc. depending on your preference).  This may cause old code to break, where it would have been converted to `variablename`.  To minimize this inconvenience, there's a quick fix for compatibility: you can find-and-replace to insert the argument `case = "old_janitor"` to preserve the old behavior of `clean_names()` as of version 0.3.1 (and thus not have to redo your scripts beyond that.)
 
 ## Major Features
 

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -8,15 +8,16 @@
 #' transliterated to ASCII.  For example, an "o" with a german umlaut over it becomes "o", and the Spanish character "enye" becomes "n". 
 #'
 #' @param dat the input data.frame.
-#' @param case The desired target case (default is \code{"snake"}), provided as one of the following:
+#' @param case The desired target case (default is \code{"snake"}), indicated by these possible values:
 #' \itemize{
-#'  \item{snake_case: \code{"snake"}}
-#'  \item{lowerCamel: \code{"lower_camel"} or \code{"small_camel"}}
-#'  \item{UpperCamel: \code{"upper_camel"} or \code{"big_camel"}}
-#'  \item{ALL_CAPS: \code{"screaming_snake"} or \code{"all_caps"}}
-#'  \item{lowerUPPER: \code{"lower_upper"}}
-#'  \item{UPPERlower: \code{"upper_lower"}}
-#'  \item{old_janitor: legacy compatibility option to preserve behavior of \code{clean_names} in janitor versions <= 0.3.1 (prior to addition of the "case" argument)}
+#'  \item{\code{"snake"} produces snake_case} 
+#'  \item{\code{"lower_camel"} or \code{"small_camel"} produces lowerCamel}
+#'  \item{\code{"upper_camel"} or \code{"big_camel"} produces UpperCamel}
+#'  \item{\code{"screaming_snake"} or \code{"all_caps"} produces ALL_CAPS}
+#'  \item{\code{"lower_upper"} produces lowerUPPER}
+#'  \item{\code{"upper_lower"} produces UPPERlower}
+#'  \item{\code{old_janitor}: legacy compatibility option to preserve behavior of \code{clean_names} prior to addition of the "case" argument(janitor versions <= 0.3.1 )}.  Provided as a quick fix for old scripts broken by the changes to \code{clean_names} in janitor v1.0.
+#'  \item{\code{"parsed"}, \code{"mixed"}, \code{"none"}, \code{"internal_parsing"}: less-common cases offered by \code{snakecase::to_any_case}.  See \code{\link[snakecase]{to_any_case}} for details.}
 #'  }
 #'  
 #' @return Returns the data.frame with clean names.
@@ -25,7 +26,7 @@
 #' # not run:
 #' # clean_names(poorly_named_df)
 #' 
-#' # or with the pipe character from dplyr:
+#' # or pipe in the input data.frame:
 #' # poorly_named_df %>% clean_names()
 #' 
 #' # if you prefer camelCase variable names:
@@ -35,9 +36,9 @@
 #' # library(readxl)
 #' # readxl("messy_excel_file.xlsx") %>% clean_names()
 
-clean_names <- function(dat, case = c("snake", "small_camel", "big_camel", "screaming_snake", 
-                                      "parsed", "mixed", "lower_upper", "upper_lower",
-                                      "all_caps", "lower_camel", "upper_camel", "old_janitor")) {
+clean_names <- function(dat, case = c("snake", "lower_camel", "upper_camel", "screaming_snake", 
+                                      "lower_upper", "upper_lower", "all_caps", "small_camel",
+                                      "big_camel", "old_janitor", "parsed", "mixed")) {
   
   # old behavior, to provide easy fix for people whose code breaks with the snakecase integration
   case <- match.arg(case)
@@ -58,9 +59,10 @@ clean_names <- function(dat, case = c("snake", "small_camel", "big_camel", "scre
     gsub("^[[:space:][:punct:]]+", "", .) %>% # remove leading spaces & punctuation
     make.names(.) %>%
     # Handle dots, multiple underscores, case conversion, string transliteration
+    # Parsing option 4 removes underscores around numbers, #153
     snakecase::to_any_case(case = case, sep_in = "\\.", 
-                           transliterations = c("Latin-ASCII"))
-  
+                           transliterations = c("Latin-ASCII"), parsing_option = 4)
+
   # Handle duplicated names - they mess up dplyr pipelines
   # This appends the column number to repeated instances of duplicate variable names
   dupe_count <- vapply(1:length(new_names), function(i) { 

--- a/man/clean_names.Rd
+++ b/man/clean_names.Rd
@@ -4,22 +4,23 @@
 \alias{clean_names}
 \title{Cleans names of a data.frame.}
 \usage{
-clean_names(dat, case = c("snake", "small_camel", "big_camel",
-  "screaming_snake", "parsed", "mixed", "lower_upper", "upper_lower",
-  "all_caps", "lower_camel", "upper_camel", "old_janitor"))
+clean_names(dat, case = c("snake", "lower_camel", "upper_camel",
+  "screaming_snake", "lower_upper", "upper_lower", "all_caps", "small_camel",
+  "big_camel", "old_janitor", "parsed", "mixed"))
 }
 \arguments{
 \item{dat}{the input data.frame.}
 
-\item{case}{The desired target case (default is \code{"snake"}), provided as one of the following:
+\item{case}{The desired target case (default is \code{"snake"}), indicated by these possible values:
 \itemize{
- \item{snake_case: \code{"snake"}}
- \item{lowerCamel: \code{"lower_camel"} or \code{"small_camel"}}
- \item{UpperCamel: \code{"upper_camel"} or \code{"big_camel"}}
- \item{ALL_CAPS: \code{"screaming_snake"} or \code{"all_caps"}}
- \item{lowerUPPER: \code{"lower_upper"}}
- \item{UPPERlower: \code{"upper_lower"}}
- \item{old_janitor: legacy compatibility option to preserve behavior of \code{clean_names} in janitor versions <= 0.3.1 (prior to addition of the "case" argument)}
+ \item{\code{"snake"} produces snake_case} 
+ \item{\code{"lower_camel"} or \code{"small_camel"} produces lowerCamel}
+ \item{\code{"upper_camel"} or \code{"big_camel"} produces UpperCamel}
+ \item{\code{"screaming_snake"} or \code{"all_caps"} produces ALL_CAPS}
+ \item{\code{"lower_upper"} produces lowerUPPER}
+ \item{\code{"upper_lower"} produces UPPERlower}
+ \item{\code{old_janitor}: legacy compatibility option to preserve behavior of \code{clean_names} prior to addition of the "case" argument(janitor versions <= 0.3.1 )}.  Provided as a quick fix for old scripts broken by the changes to \code{clean_names} in janitor v1.0.
+ \item{\code{"parsed"}, \code{"mixed"}, \code{"none"}, \code{"internal_parsing"}: less-common cases offered by \code{snakecase::to_any_case}.  See \code{\link[snakecase]{to_any_case}} for details.}
  }}
 }
 \value{
@@ -36,7 +37,7 @@ transliterated to ASCII.  For example, an "o" with a german umlaut over it becom
 # not run:
 # clean_names(poorly_named_df)
 
-# or with the pipe character from dplyr:
+# or pipe in the input data.frame:
 # poorly_named_df \%>\% clean_names()
 
 # if you prefer camelCase variable names:

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -1,13 +1,13 @@
 # Tests for data.frame renaming function
 
 library(janitor)
-context("data.frame name cleaning")
+context("clean_names")
 
-test_df <- data.frame(matrix(ncol = 18) %>% as.data.frame())
+test_df <- data.frame(matrix(ncol = 20) %>% as.data.frame())
 names(test_df) <- c("sp ace", "repeated", "a**^@", "%", "*", "!",
                     "d(!)9", "REPEATED", "can\"'t", "hi_`there`", "  leading spaces",
                     "€", "ação", "Farœ", "a b c d e f", "testCamelCase", "!leadingpunct",
-                    "average # of days")
+                    "average # of days", "jan2009sales", "jan 2009 sales")
 
 clean <- clean_names(test_df, "snake")
 
@@ -31,6 +31,8 @@ test_that("Names are cleaned appropriately", {
   expect_equal(names(clean)[16], "test_camel_case") # for testing alternating cases below with e.g., case = "upper_lower"
   expect_equal(names(clean)[17], "leadingpunct") # for testing alternating cases below with e.g., case = "upper_lower"
   expect_equal(names(clean)[18], "average_number_of_days") # for testing alternating cases below with e.g., case = "upper_lower"
+  expect_equal(names(clean)[19], "jan2009sales") # no separator around number-word boundary if not existing already
+  expect_equal(names(clean)[20], "jan_2009_sales") # yes separator around number-word boundary if it existed
 })
 
 test_that("Returns a data.frame", {
@@ -40,21 +42,25 @@ test_that("Returns a data.frame", {
 test_that("Tests for cases beyond default snake", {
   expect_equal(names(clean_names(test_df, "small_camel")),
                c("spAce", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2", 
-                 "cant", "hiThere", "leadingSpaces", "x_3", "acao", "faroe", "aBCDEF", "testCamelCase", "leadingpunct", "averageNumberOfDays"))
+                 "cant", "hiThere", "leadingSpaces", "x_3", "acao", "faroe", "aBCDEF", "testCamelCase", "leadingpunct", "averageNumberOfDays", "jan2009Sales", "jan2009Sales_2"))
   expect_equal(names(clean_names(test_df, "big_camel")),
                c("SpAce", "Repeated", "A", "Percent", "X", "X_2", "D9", "Repeated_2", 
-                 "Cant", "HiThere", "LeadingSpaces", "X_3", "Acao", "Faroe", "ABCDEF", "TestCamelCase", "Leadingpunct", "AverageNumberOfDays"))
+                 "Cant", "HiThere", "LeadingSpaces", "X_3", "Acao", "Faroe", "ABCDEF", "TestCamelCase", "Leadingpunct", "AverageNumberOfDays", "Jan2009Sales", "Jan2009Sales_2"))
   expect_equal(names(clean_names(test_df, "all_caps")),
                c("SP_ACE", "REPEATED", "A", "PERCENT", "X", "X_2", "D_9", "REPEATED_2", 
-                 "CANT", "HI_THERE", "LEADING_SPACES", "X_3", "ACAO", "FAROE", "A_B_C_D_E_F", "TEST_CAMEL_CASE", "LEADINGPUNCT", "AVERAGE_NUMBER_OF_DAYS"))
+                 "CANT", "HI_THERE", "LEADING_SPACES", "X_3", "ACAO", "FAROE", "A_B_C_D_E_F", "TEST_CAMEL_CASE", "LEADINGPUNCT", "AVERAGE_NUMBER_OF_DAYS", "JAN2009SALES", "JAN_2009_SALES"))
   expect_equal(names(clean_names(test_df, "lower_upper")),
                c("spACE", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2", 
-                 "cant", "hiTHERE", "leadingSPACES", "x_3", "acao", "faroe", "aBcDeF", "testCAMELcase", "leadingpunct", "averageNUMBERofDAYS"))
+                 "cant", "hiTHERE", "leadingSPACES", "x_3", "acao", "faroe", "aBcDeF", "testCAMELcase", "leadingpunct", "averageNUMBERofDAYS", "jan2009SALES", "jan2009SALES_2"))
   expect_equal(names(clean_names(test_df, "upper_lower")),
                c("SPace", "REPEATED", "A", "PERCENT", "X", "X_2", "D9", "REPEATED_2", 
-                 "CANT", "HIthere", "LEADINGspaces", "X_3", "ACAO", "FAROE", "AbCdEf", "TESTcamelCASE", "LEADINGPUNCT", "AVERAGEnumberOFdays"))
+                 "CANT", "HIthere", "LEADINGspaces", "X_3", "ACAO", "FAROE", "AbCdEf", "TESTcamelCASE", "LEADINGPUNCT", "AVERAGEnumberOFdays", "JAN2009sales", "JAN2009sales_2"))
   expect_equal(names(clean_names(test_df, "old_janitor")),
                c("sp_ace", "repeated", "a", "percent", "x", "x_2", "d_9", "repeated_2", 
                  "cant", "hi_there", "leading_spaces", "x_3", "ação", "farœ", 
-                 "a_b_c_d_e_f", "testcamelcase", "x_leadingpunct", "average_of_days"))
+                 "a_b_c_d_e_f", "testcamelcase", "x_leadingpunct", "average_of_days", "jan2009sales", "jan_2009_sales"))
+  # check that alias arguments yield identical outputs
+  expect_equal(names(clean_names(test_df, "screaming_snake")), names(clean_names(test_df, "all_caps")))
+  expect_equal(names(clean_names(test_df, "big_camel")), names(clean_names(test_df, "upper_camel")))
+  expect_equal(names(clean_names(test_df, "small_camel")), names(clean_names(test_df, "lower_camel")))
 })


### PR DESCRIPTION
closes #153.  Now `email2` stays `email2` instead of becoming `email_2`, but `email 2` still becomes `email_2`.