### PR TITLE
changed link catalog of functions. 

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -67,7 +67,7 @@ The current development version is significantly ahead of version 0.3.0 on CRAN 
 
 ## Using janitor
 
-Below are quick examples of how janitor tools are commonly used.  A full description of each function can be found in janitor's [catalog of functions](https://github.com/sfirke/janitor/blob/master/vignettes/introduction.md).  
+Below are quick examples of how janitor tools are commonly used.  A full description of each function can be found in janitor's [catalog of functions](https://sfirke.github.io/janitor/reference/index.html).  
 
 ### Cleaning dirty data
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -67,7 +67,7 @@ The current development version is significantly ahead of version 0.3.0 on CRAN 
 
 ## Using janitor
 
-Below are quick examples of how janitor tools are commonly used.  A full description of each function can be found in janitor's [catalog of functions](https://sfirke.github.io/janitor/reference/index.html).  
+Below are quick examples of how janitor tools are commonly used.  A full description of each function can be found in janitor's [catalog of functions vignette](https://github.com/sfirke/janitor/blob/master/vignettes/janitor.md).  
 
 ### Cleaning dirty data
 


### PR DESCRIPTION
Previous link was pointing to a 404 page. Updated link to https://sfirke.github.io/janitor/reference/index.html


## Description
changed link to reference page of package website.

## Related Issue
 Should and hopefully fixes Issue 23


