### PR TITLE
Incorporate changes from lintr and goodpractice

### DIFF
--- a/R/adorn_crosstab.R
+++ b/R/adorn_crosstab.R
@@ -25,8 +25,6 @@ adorn_crosstab <- function(dat, denom = "row", show_n = TRUE, digits = 1, show_t
   showing_col_totals <- (show_totals & denom %in% c("col", "all"))
   showing_row_totals <- (show_totals & denom %in% c("row", "all"))
 
-  complete_n <- sum(dat[, -1], na.rm = TRUE) # capture for percent calcs before any totals col/row is added
-
   if (showing_col_totals) {
     dat <- adorn_totals(dat, "col")
   }

--- a/R/adorn_crosstab.R
+++ b/R/adorn_crosstab.R
@@ -65,7 +65,7 @@ paste_ns <- function(perc_df, n_df) {
 
   # paste the results together
   pasted <- paste(perc_matrix, " (", n_matrix, ")", sep = "") %>% # paste the matrices
-    sapply(., fix_parens_whitespace) %>% # apply the whitespace cleaning function to the resulting vector
+    vapply(., fix_parens_whitespace, "") %>% # apply the whitespace cleaning function to the resulting vector
     matrix(., nrow = nrow(n_matrix), dimnames = dimnames(perc_matrix)) %>% # cast as matrix, then data.frame
     dplyr::as_data_frame()
 

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -69,7 +69,7 @@ clean_names <- function(dat, case = c(
 
   # Handle duplicated names - they mess up dplyr pipelines
   # This appends the column number to repeated instances of duplicate variable names
-  dupe_count <- vapply(1:length(new_names), function(i) {
+  dupe_count <- vapply(seq_along(new_names), function(i) {
     sum(new_names[i] == new_names[1:i])
   }, integer(1))
 
@@ -99,7 +99,7 @@ old_clean_names <- function(dat) {
 
   # Handle duplicated names - they mess up dplyr pipelines
   # This appends the column number to repeated instances of duplicate variable names
-  dupe_count <- vapply(1:length(new_names), function(i) {
+  dupe_count <- vapply(seq_along(new_names), function(i) {
     sum(new_names[i] == new_names[1:i])
   }, integer(1))
 


### PR DESCRIPTION
A few minor improvements, e.g., `sapply` becomes `vapply`.  Nothing of major import.  Fixed #172 .