### PR TITLE
Add time handling to excel_numeric_to_date

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Simple Tools for Examining and Cleaning Dirty Data
 Version: 1.0.1.9000
 Authors@R: c(person("Sam", "Firke", email = "samuel.firke@gmail.com", role = c("aut", "cre")),
     person("Chris", "Haid", email = "chrishaid@gmail.com", role = "ctb"),
-    person("Ryan", "Knight", email = "ryangknight@gmail.com", role = "ctb"))
+    person("Ryan", "Knight", email = "ryangknight@gmail.com", role = "ctb"),
+    person("Bill", "Denney", email = "wdenney@humanpredictions.com", role="ctb"))
 Description: The main janitor functions can: perfectly format data.frame column
     names; provide quick counts of variable combinations (i.e., frequency
     tables and crosstabs); and isolate duplicate records. Other janitor functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@
 
 The new function `row_to_names` handles the case where a dirty data file is read in with its names stored as a row of the data.frame, rather than in the names.  This function sets the names of the data.frame to this row and optionally cleans up the rows above and including where the names were stored.  Thanks to **@billdenney** for writing this feature.
 
+## Minor features
+
+`excel_numeric_to_date()` can now provide times as well with the new `include_time` argument.
+
+## Breaking changes
+
+As part of `excel_numeric_to_date()` handling times, if a Date-only result is requested (the default) any fractional part of the date is now removed.  The date itself is identical, but the underlying object now has only the integer part of the date.
+
 # janitor 1.0.0  (2018-03-17)
 
 ## Release summary

--- a/R/excel_dates.R
+++ b/R/excel_dates.R
@@ -8,23 +8,57 @@
 #'
 #' @param date_num numeric vector of serial numbers to convert.
 #' @param date_system the date system, either \code{"modern"} or \code{"mac pre-2011"}.
-#' @return Returns a vector of class Date.
+#' @param include_time Include the time (hours, minutes, seconds) in the output? (See details)
+#' @param round_seconds Round the seconds to an integer (only has an effect when \code{include_time} is \code{TRUE})?
+#' @return Returns a vector of class Date if \code{include_time} is \code{FALSE}.  Returns a vector of class POSIXlt if \code{include_time} is \code{TRUE}.
+#' @details When using \code{include_time=TRUE} the returned object will not
+#'   include a time zone since excel does not store dates and times with time
+#'   zones.  When adding time zones, ensure that any conversion done does not
+#'   change the intended time including if the time is or is not in daylight
+#'   savings time.  Also, days with leap seconds will not be accurately handled
+#'   as they do not appear to be accurately handled by Windows (as described in
+#'   https://support.microsoft.com/en-us/help/2722715/support-for-the-leap-second).
 #' @export
 #' @examples
 #' excel_numeric_to_date(40000)
+#' excel_numeric_to_date(40000.5) # No time is included
+#' excel_numeric_to_date(40000.5, include_time=TRUE) # Time is included
+#' excel_numeric_to_date(40000.521, include_time=TRUE) # Time is included
+#' excel_numeric_to_date(40000.521, include_time=TRUE, round_seconds=FALSE) # Time with fractional seconds is included
 
 # Converts a numeric value like 42414 into a date "2016-02-14"
 
-excel_numeric_to_date <- function(date_num, date_system = "modern") {
+excel_numeric_to_date <- function(date_num, date_system = "modern", include_time=FALSE, round_seconds=TRUE) {
   if (!is.numeric(date_num)) {
     stop("argument `date_num` must be of class numeric")
   }
 
-  if (date_system == "mac pre-2011") {
-    as.Date(date_num, origin = "1904-01-01")
-  } else if (date_system == "modern") {
-    as.Date(date_num, origin = "1899-12-30")
-  } else {
-    stop("argument 'created' must be one of 'mac pre-2011' or 'modern'")
+  ret <-
+    if (date_system == "mac pre-2011") {
+      as.Date(floor(date_num), origin = "1904-01-01")
+    } else if (date_system == "modern") {
+      as.Date(floor(date_num), origin = "1899-12-30")
+    } else {
+      stop("argument 'created' must be one of 'mac pre-2011' or 'modern'")
+    }
+  if (include_time) {
+    ret <- as.POSIXlt(ret)
+    total_sec <- 86400*(date_num %% 1)
+    ret$sec <- total_sec %% 60
+    if (round_seconds) {
+      ret$sec <- round(ret$sec)
+    }
+    ret$min <- floor(total_sec/60) %% 60
+    ret$hour <- floor(total_sec/3600)
+    # Excel does not store the timezone; remove all ways of storing timezone and
+    # clean related fields (isdst).  Multiple methods are used by R for storing
+    # timezone information in POSIXlt objects
+    # (https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17437), and an
+    # attempt is made to clear all of them.
+    attr(ret, "tzone") <- NULL
+    ret$isdst <- 0L
+    ret$zone <- NULL
+    ret$gmtoff <- NULL
   }
+  ret
 }

--- a/man/excel_numeric_to_date.Rd
+++ b/man/excel_numeric_to_date.Rd
@@ -4,15 +4,20 @@
 \alias{excel_numeric_to_date}
 \title{Convert dates encoded as serial numbers to Date class.}
 \usage{
-excel_numeric_to_date(date_num, date_system = "modern")
+excel_numeric_to_date(date_num, date_system = "modern",
+  include_time = FALSE, round_seconds = TRUE)
 }
 \arguments{
 \item{date_num}{numeric vector of serial numbers to convert.}
 
 \item{date_system}{the date system, either \code{"modern"} or \code{"mac pre-2011"}.}
+
+\item{include_time}{Include the time (hours, minutes, seconds) in the output? (See details)}
+
+\item{round_seconds}{Round the seconds to an integer (only has an effect when \code{include_time} is \code{TRUE})?}
 }
 \value{
-Returns a vector of class Date.
+Returns a vector of class Date if \code{include_time} is \code{FALSE}.  Returns a vector of class POSIXlt if \code{include_time} is \code{TRUE}.
 }
 \description{
 Converts numbers like \code{42370} into date values like \code{2016-01-01}.
@@ -20,6 +25,19 @@ Converts numbers like \code{42370} into date values like \code{2016-01-01}.
 Defaults to the modern Excel date encoding system. However, Excel for Mac 2008 and earlier Mac versions of Excel used a different date system. To determine what platform to specify: if the date 2016-01-01 is represented by the number 42370 in your spreadsheet, it's the modern system.  If it's 40908, it's the old Mac system.
 More on date encoding systems at http://support.office.com/en-us/article/Date-calculations-in-Excel-e7fe7167-48a9-4b96-bb53-5612a800b487.
 }
+\details{
+When using \code{include_time=TRUE} the returned object will not
+  include a time zone since excel does not store dates and times with time
+  zones.  When adding time zones, ensure that any conversion done does not
+  change the intended time including if the time is or is not in daylight
+  savings time.  Also, days with leap seconds will not be accurately handled
+  as they do not appear to be accurately handled by Windows (as described in
+  https://support.microsoft.com/en-us/help/2722715/support-for-the-leap-second).
+}
 \examples{
 excel_numeric_to_date(40000)
+excel_numeric_to_date(40000.5) # No time is included
+excel_numeric_to_date(40000.5, include_time=TRUE) # Time is included
+excel_numeric_to_date(40000.521, include_time=TRUE) # Time is included
+excel_numeric_to_date(40000.521, include_time=TRUE, round_seconds=FALSE) # Time with fractional seconds is included
 }

--- a/tests/testthat/test-date-conversion.R
+++ b/tests/testthat/test-date-conversion.R
@@ -14,3 +14,18 @@ test_that("Bad inputs handled appropriately", {
   expect_error(excel_numeric_to_date(40908, "bad string"), "argument 'created' must be one of 'mac pre-2011' or 'modern'")
   expect_error(excel_numeric_to_date(40908, 4), "argument 'created' must be one of 'mac pre-2011' or 'modern'")
 })
+
+test_that("time handling works correctly", {
+  expect_equal(excel_numeric_to_date(42370, include_time=TRUE),
+               as.POSIXlt("2016-01-01"),
+               info="Time inclusion works with an integer date")
+  expect_equal(excel_numeric_to_date(42370.521, include_time=TRUE),
+               as.POSIXlt("2016-01-01 12:30:14"),
+               info="Time inclusion works with a fractional date/time and seconds rounded")
+  expect_equal(excel_numeric_to_date(42370.521, include_time=TRUE, round_seconds=FALSE),
+               as.POSIXlt("2016-01-01 12:30:14.4"),
+               info="Time inclusion works with a fractional date/time and seconds not rounded")
+  expect_equal(excel_numeric_to_date(42370.521, include_time=FALSE),
+               as.Date("2016-01-01"),
+               info="Time inclusion works with a fractional date/time and only the date kept.")
+})


### PR DESCRIPTION
Fix #210

A few notes:

I'm not sure if you want to describe the minor change of taking the floor of the value as a breaking change in the NEWS file.  It is very subtle and people shouldn't have been going into the date object that way.

While working up the test cases, I found a bug in base R (https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17437).  I worked around it in the result, and I think that the if the behavior changes, the code should be fine long-term.