### PR TITLE
Correct NA handling in excel_numeric_to_date

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: janitor
 Title: Simple Tools for Examining and Cleaning Dirty Data
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: c(person("Sam", "Firke", email = "samuel.firke@gmail.com", role = c("aut", "cre")),
     person("Chris", "Haid", email = "chrishaid@gmail.com", role = "ctb"),
     person("Ryan", "Knight", email = "ryangknight@gmail.com", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# janitor 1.1.1
+
+## Bug fixes
+
+* `excel_numeric_to_date()` again handles NA correctly (#220).
+
 # janitor 1.1.0 (2018-07-17)
 
 ## Release summary

--- a/R/excel_dates.R
+++ b/R/excel_dates.R
@@ -30,7 +30,14 @@
 # Converts a numeric value like 42414 into a date "2016-02-14"
 
 excel_numeric_to_date <- function(date_num, date_system = "modern", include_time = FALSE, round_seconds = TRUE) {
-  if (!is.numeric(date_num)) {
+  if (all(is.na(date_num))) {
+    # For NA input, return the expected type of NA output.
+    if (include_time) {
+      return(as.POSIXlt(as.character(date_num)))
+    } else {
+      return(as.Date(as.character(date_num)))
+    }
+  } else if (!is.numeric(date_num)) {
     stop("argument `date_num` must be of class numeric")
   }
 
@@ -38,7 +45,7 @@ excel_numeric_to_date <- function(date_num, date_system = "modern", include_time
   date_num_days <- (date_num * 86400L + 0.001) %/% 86400L
   date_num_days_no_floating_correction <- date_num %/% 1
   # If the day rolls over due to machine precision, then the seconds should be zero
-  mask_day_rollover <- date_num_days > date_num_days_no_floating_correction
+  mask_day_rollover <- !is.na(date_num) & date_num_days > date_num_days_no_floating_correction
   date_num_seconds <- (date_num - date_num_days) * 86400
   date_num_seconds[mask_day_rollover] <- 0
   if (round_seconds) {

--- a/tests/testthat/test-date-conversion.R
+++ b/tests/testthat/test-date-conversion.R
@@ -48,3 +48,19 @@ test_that("time handling at the edge of the next date works correctly", {
   expect_equal(excel_numeric_to_date(42002 - 0.0011/86400, include_time=TRUE, round_seconds=TRUE),
                as.POSIXlt("2014-12-29"))
 })
+
+test_that("excel_numeric_to_date handles NA", {
+  expect_equal(excel_numeric_to_date(NA),
+               as.Date(NA_character_),
+               info="Return NA output of the correct class (Date) for NA input.")
+  expect_equal(excel_numeric_to_date(NA, include_time=TRUE),
+               as.POSIXlt(NA_character_),
+               info="Return NA output of the correct class (POSIXlt) for NA input.")
+  expect_equal(excel_numeric_to_date(c(43088, NA)),
+               as.Date(floor(c(43088, NA)), origin = "1899-12-30"),
+               info="Return NA output as part of a vector of inputs correctly")
+  expect_equal(excel_numeric_to_date(c(43088, NA), include_time=TRUE),
+               structure(as.POSIXlt(as.Date(floor(c(43088, NA)), origin = "1899-12-30")),
+                         tzone=NULL),
+               info="Return NA output as part of a vector of inputs correctly")
+})

--- a/tests/testthat/test-date-conversion.R
+++ b/tests/testthat/test-date-conversion.R
@@ -39,10 +39,19 @@ test_that("time handling at the edge of a minute works correctly", {
 test_that("time handling at the edge of the next date works correctly", {
   expect_warning(excel_numeric_to_date(42002 - 0.0005/86400, include_time=TRUE, round_seconds=FALSE),
                  regexp="1 date_num values are within 0.001 sec of a later date and were rounded up to the next day.")
-  expect_equal(excel_numeric_to_date(42002 - 0.0005/86400, include_time=TRUE, round_seconds=FALSE),
-               as.POSIXlt("2014-12-29"))
-  expect_equal(excel_numeric_to_date(42002 - 0.0005/86400, include_time=TRUE, round_seconds=TRUE),
-               as.POSIXlt("2014-12-29"))
+  # suppress warning on next two tests, that aspect is identical to preceding call where warning is checked
+  expect_equal(
+    suppressWarnings(
+      excel_numeric_to_date(42002 - 0.0005/86400, include_time=TRUE, round_seconds=FALSE)
+    ),
+    as.POSIXlt("2014-12-29")
+  )
+  expect_equal(
+    suppressWarnings(
+      excel_numeric_to_date(42002 - 0.0005/86400, include_time=TRUE, round_seconds=TRUE)
+    ),
+    as.POSIXlt("2014-12-29")
+  )
   expect_equal(excel_numeric_to_date(42002 - 0.0011/86400, include_time=TRUE, round_seconds=FALSE),
                as.POSIXlt("2014-12-28 23:59:59.998"))
   expect_equal(excel_numeric_to_date(42002 - 0.0011/86400, include_time=TRUE, round_seconds=TRUE),


### PR DESCRIPTION
Fix #220

One slight inconsistency with the existing code is that with all NA input (e.g. `excel_numeric_to_date(NA, include_time=TRUE)` the time zone is not unset).