### PR TITLE
Upd snakecase version regarding upcoming changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Depends:
 Imports:
     dplyr (>= 0.7.0),
     tidyr (>= 0.7.0),
-    snakecase (>= 0.9.0),
+    snakecase (>= 0.9.2),
     magrittr,
     purrr,
     rlang


### PR DESCRIPTION
## Description
Update Version number for snakecase to 0.9.2

This ensures that `janitor::clean_names()`, which I will make also a small change to. Will also work with the snakecase package from version 0.9.3 on as there is a little non-backward compatible change introduced.

In particular the argument `parsing_option = 4` from `snakecase::to_any_case()` will be replaced inside `clean_names()` with the settings: `parsing_option = 1` and `numerals = "asis"`. 

This is just a small backend change and no behaviour will change so the current tests in janitor suffice to further check the behaviour.

## Related Issue
Following the issue from the snakecase package, see here:
https://github.com/Tazinho/snakecase/issues/147