### PR TITLE
correct function reference in clean_names.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     rlang
 License: MIT + file LICENSE
 LazyData: true
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 Suggests:
     testthat,
     knitr,

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -34,7 +34,7 @@
 #'
 #' # not run:
 #' # library(readxl)
-#' # readxl("messy_excel_file.xlsx") %>% clean_names()
+#' # read_excel("messy_excel_file.xlsx") %>% clean_names()
 
 clean_names <- function(dat, case = c(
                         "snake", "lower_camel", "upper_camel", "screaming_snake",

--- a/man/clean_names.Rd
+++ b/man/clean_names.Rd
@@ -5,8 +5,8 @@
 \title{Cleans names of a data.frame.}
 \usage{
 clean_names(dat, case = c("snake", "lower_camel", "upper_camel",
-  "screaming_snake", "lower_upper", "upper_lower", "all_caps", "small_camel",
-  "big_camel", "old_janitor", "parsed", "mixed"))
+  "screaming_snake", "lower_upper", "upper_lower", "all_caps",
+  "small_camel", "big_camel", "old_janitor", "parsed", "mixed"))
 }
 \arguments{
 \item{dat}{the input data.frame.}
@@ -45,5 +45,5 @@ transliterated to ASCII.  For example, an "o" with a German umlaut over it becom
 
 # not run:
 # library(readxl)
-# readxl("messy_excel_file.xlsx") \%>\% clean_names()
+# read_excel("messy_excel_file.xlsx") \%>\% clean_names()
 }

--- a/man/crosstab.Rd
+++ b/man/crosstab.Rd
@@ -8,8 +8,8 @@
 \usage{
 crosstab(...)
 
-\method{crosstab}{default}(vec1, vec2, percent = "none", show_na = TRUE,
-  ...)
+\method{crosstab}{default}(vec1, vec2, percent = "none",
+  show_na = TRUE, ...)
 
 \method{crosstab}{data.frame}(.data, ...)
 }

--- a/man/row_to_names.Rd
+++ b/man/row_to_names.Rd
@@ -4,7 +4,8 @@
 \alias{row_to_names}
 \title{Elevate a row to be the column names of a data.frame.}
 \usage{
-row_to_names(dat, row_number, remove_row = TRUE, remove_rows_above = TRUE)
+row_to_names(dat, row_number, remove_row = TRUE,
+  remove_rows_above = TRUE)
 }
 \arguments{
 \item{dat}{The input data.frame}

--- a/man/tabyl.Rd
+++ b/man/tabyl.Rd
@@ -8,8 +8,8 @@
 \usage{
 tabyl(dat, ...)
 
-\method{tabyl}{default}(dat, show_na = TRUE, show_missing_levels = TRUE,
-  ...)
+\method{tabyl}{default}(dat, show_na = TRUE,
+  show_missing_levels = TRUE, ...)
 
 \method{tabyl}{data.frame}(dat, var1, var2, var3, show_na = TRUE,
   show_missing_levels = TRUE, ...)


### PR DESCRIPTION
## Description
Fixed example to reference the correct function in clean_names.R

As a result of rebuilding with roxygen 6.1.0 (R3.5.1) a few *.Rd files are updated due to how it truncates text and wraps it over multiple lines


## Related Issue
fixes #236 