### PR TITLE
Prevent integer overflow with integer input to excel_numeric_to_date() (fix #241)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ This new function can be supplied as a value for the `.name_repair` argument of 
 ## Bug fixes
 
 * `remove_empty()` now works with matrices (returning a matrix).  (#215)  Thanks to **@jsta** for reporting and **@billdenney** for patching.
+* `excel_numeric_to_date()` no longer gives an overflow error for integer input (for dates since 1968).  (#241)  Thanks to **@hideaki** for reporting and **@billdenney** for patching.
 
 # janitor 1.1.1 (2018-07-30)
 

--- a/R/excel_dates.R
+++ b/R/excel_dates.R
@@ -39,8 +39,9 @@ excel_numeric_to_date <- function(date_num, date_system = "modern", include_time
     stop("argument `date_num` must be of class numeric")
   }
 
-  # Manage floating point imprecision
-  date_num_days <- (date_num * 86400L + 0.001) %/% 86400L
+  # Manage floating point imprecision; coerce to double to avoid inteter
+  # overflow.
+  date_num_days <- (as.double(date_num) * 86400L + 0.001) %/% 86400L
   date_num_days_no_floating_correction <- date_num %/% 1
   # If the day rolls over due to machine precision, then the seconds should be zero
   mask_day_rollover <- !is.na(date_num) & date_num_days > date_num_days_no_floating_correction

--- a/tests/testthat/test-date-conversion.R
+++ b/tests/testthat/test-date-conversion.R
@@ -91,3 +91,8 @@ test_that("time zone setting works", {
   # Then delete prior test as it will fail
 
 })
+
+test_that("integer Excel dates do not overflow (ref issue #241)", {
+  expect_equal(excel_numeric_to_date(42370L),
+               excel_numeric_to_date(42370))
+})


### PR DESCRIPTION
Coerce all numeric input to double before calculating output.