### PR TITLE
Create clean_names() method for sf objects

### DIFF
--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -52,9 +52,12 @@ clean_names <- function(dat, case = c(
 # sf method for clean names
 
 clean_names.sf <- function(x, ...) {
-    ret <- clean_names(x)
-    st_geometry(ret) <- names(ret)[ncol(ret)] # geometry is always last column
-    ret
+  sf_names <- names(x) # get old names
+  n_cols <- length(x)-1 # identify ending column index to clean
+  sf_cleaned <- make_clean_names(sf_names[1:n_cols]) # clean all but last column
+  names(x)[1:n_cols] <- sf_cleaned # rename original df
+  return(x) # return it
 }
+
 
 

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -48,3 +48,13 @@ clean_names <- function(dat, case = c(
   if(!is.data.frame(dat)){stop( "clean_names() must be called on a data.frame.  Consider janitor::make_clean_names() for other cases of manipulating vectors of names.") }
   stats::setNames(dat, make_clean_names(names(dat), case = case))
 }
+
+# sf method for clean names
+
+clean_names.sf <- function(x, ...) {
+    ret <- clean_names(x)
+    st_geometry(ret) <- names(ret)[ncol(ret)] # geometry is always last column
+    ret
+}
+
+


### PR DESCRIPTION
Based on previous input and the awesome `make_clean_names()` function, this pull request cleans all names but the geometry feature for sf objects. It is exceptionally light weight and causes no errors on my testing. 