### PR TITLE
Specify text for adorn_total()

### DIFF
--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -15,7 +15,7 @@
 #'   adorn_totals()
 
 
-adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE) {
+adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "Total") {
   # if input is a list, call purrr::map to recursively apply this function to each data.frame
   if (is.list(dat) && !is.data.frame(dat)) {
     purrr::map(dat, adorn_totals, where, fill, na.rm)
@@ -63,7 +63,7 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE) {
       }
 
       col_totals <- purrr::map_df(dat, col_sum)
-      col_totals[1, 1] <- "Total" # replace first column value with "Total"
+      col_totals[1, 1] <- name # replace first column value with name argument
       dat[(nrow(dat) + 1), ] <- col_totals[1, ] # insert totals_col as last row in dat
     }
 
@@ -75,7 +75,7 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE) {
         dplyr::select_if(is.numeric) %>%
         dplyr::transmute(Total = rowSums(., na.rm = na.rm))
 
-      dat$Total <- row_totals$Total
+      dat[[name]] <- row_totals$Total
     }
 
     dat

--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -7,6 +7,7 @@
 #' @param where one of "row", "col", or \code{c("row", "col")}
 #' @param fill if there are multiple non-numeric columns, what string should fill the bottom row of those columns?
 #' @param na.rm should missing values (including NaN) be omitted from the calculations?
+#' @param name name of the totals column or row 
 #' @return Returns a data.frame augmented with a totals row, column, or both.  The data.frame is now also of class \code{tabyl} and stores information about the attached totals and underlying data in the tabyl attributes.
 #' @export
 #' @examples

--- a/man/adorn_totals.Rd
+++ b/man/adorn_totals.Rd
@@ -4,7 +4,8 @@
 \alias{adorn_totals}
 \title{Append a totals row and/or column to a data.frame.}
 \usage{
-adorn_totals(dat, where = "row", fill = "-", na.rm = TRUE)
+adorn_totals(dat, where = "row", fill = "-", na.rm = TRUE,
+  name = "Total")
 }
 \arguments{
 \item{dat}{an input data.frame with at least one numeric column.  If given a list of data.frames, this function will apply itself to each data.frame in the list (designed for 3-way \code{tabyl} lists).}
@@ -14,6 +15,8 @@ adorn_totals(dat, where = "row", fill = "-", na.rm = TRUE)
 \item{fill}{if there are multiple non-numeric columns, what string should fill the bottom row of those columns?}
 
 \item{na.rm}{should missing values (including NaN) be omitted from the calculations?}
+
+\item{name}{name of the totals column or row}
 }
 \value{
 Returns a data.frame augmented with a totals row, column, or both.  The data.frame is now also of class \code{tabyl} and stores information about the attached totals and underlying data in the tabyl attributes.

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -264,6 +264,20 @@ test_that("non-data.frame inputs are handled", {
   expect_error(adorn_totals(1:5), "adorn_totals() must be called on a data.frame or list of data.frames", fixed = TRUE)
 })
 
+test_that("row total name is changed", {
+  expect_equal(
+    adorn_totals(ct, name = "NewTitle")[nrow(ct) + 1, 1],
+    "NewTitle"
+  )
+})
+
+test_that("column total name is changed", {
+  expect_equal(
+    colnames(adorn_totals(ct, where = "col", name = "NewTitle"))[(ncol(ct) + 1)],
+    "NewTitle"
+  )
+})
+
 # Kind of superficial given that add_totals_ have been refactored to call adorn_totals() themselves, but might as well keep until deprecated functions are removed
 test_that("deprecated functions adorn_totals_col and adorn_totals_row function as expected", {
   expect_equal(


### PR DESCRIPTION
Adds a new argument to adorn_totals() to allow a total name other than "Total".

## Description
A new argument has been added to adorn_totals() that replaces the "Total" column/row name. The default for this argument is still "Total". Both rows and columns get the same name. 

## Related Issue
Implements #263 

## Example
```{r}
mtcars %>% 
  tabyl(am, cyl) %>% 
  adorn_totals(where = c("row", "col"), name = "AnotherTotal")
#>            am  4 6  8 AnotherTotal
#>             0  3 4 12           19
#>             1  8 3  2           13
#>  AnotherTotal 11 7 14           32
```
- [x] Tests have been added
