### PR TITLE
improve readability of make_clean_names

### DIFF
--- a/R/make_clean_names.R
+++ b/R/make_clean_names.R
@@ -53,7 +53,7 @@ make_clean_names <- function(string, case = c(
   string <- make.names(string)
   
   # Case conversion
-  to_any_case(
+  snakecase::to_any_case(
     string = string, 
     case = case, 
     abbreviations = NULL, 


### PR DESCRIPTION
I'd like to make some small adjustments regarding the readability of the `make_clean_names()` function. I think these might make it more easy to reason about current and further upcoming issues. The adjustments include:
* Some smaller adjustments in the beginning (explicit comments and removing of the pipe)
* Including also unused arguments of `to_any_case()` explicitly in the source code. This might make it easier to reason about issues, which might get solved by providing snakecase arguments to janitor users.