### PR TITLE
Simplify the logic within remove_constant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 * The `name` argument to `adorn_totals()` is correctly applied to 3-way tabyls (#306)  Thanks to **@jzadra** for reporting.
+* `remove_constant()` works correctly with tibbles in addition to data.frames and matrices which already worked (thanks to **@billdenney** for implementing).
 
 # janitor 1.2.0 (2019-04-20)
 

--- a/R/remove_empties.R
+++ b/R/remove_empties.R
@@ -70,11 +70,17 @@ remove_constant <- function(dat, na.rm = FALSE, quiet=TRUE) {
     sapply(
       X=seq_len(ncol(dat)),
       FUN=function(idx) {
+        column_to_test <-
+          if (is.matrix(dat)) {
+            dat[, idx]
+          } else {
+            dat[[idx]]
+          }
         length(unique(
           if (na.rm) {
-            stats::na.omit(dat[, idx])
+            stats::na.omit(column_to_test)
           } else {
-            dat[, idx]
+            column_to_test
           }
         )) <= 1 # the < is in case all values are NA with na.rm=TRUE
       }

--- a/R/remove_empties.R
+++ b/R/remove_empties.R
@@ -70,15 +70,13 @@ remove_constant <- function(dat, na.rm = FALSE, quiet=TRUE) {
     sapply(
       X=seq_len(ncol(dat)),
       FUN=function(idx) {
-        if (na.rm) {
-          all(is.na(dat[, idx])) ||
-            all(
-              is.na(dat[, idx]) |
-                (dat[, idx] %in% stats::na.omit(dat[, idx])[1])
-            )
-        } else {
-          all(dat[, idx] %in% dat[1, idx])
-        }
+        length(unique(
+          if (na.rm) {
+            stats::na.omit(dat[, idx])
+          } else {
+            dat[, idx]
+          }
+        )) <= 1 # the < is in case all values are NA with na.rm=TRUE
       }
     )
   if (!quiet) {

--- a/tests/testthat/test-remove-empties.R
+++ b/tests/testthat/test-remove-empties.R
@@ -121,6 +121,11 @@ test_that("remove_constant", {
     data.frame(B=c(NA, 1, 2), C=c(1, 2, NA)),
     info="NA with other values is kept with na.rm"
   )
+  expect_equal(
+    remove_constant(tibble(A=NA, B=c(NA, 1, 2), C=1)),
+    tibble(B=c(NA, 1, 2)),
+    info="tibbles are correctly handled"
+  )
 })
 
 test_that("Messages are accurate with remove_empty and remove_constant", {


### PR DESCRIPTION
This doesn't change functionality, but it simplifies the code within `remove_constant()`.  I had an error in some of my code that I thought was related to an issue with `remove_constant()` (it wasn't remove_constant's fault), but then I tried to look at the code within `remove_constant()`, and I found it difficult to read-- so I simplified it.

Since this is not a functional change, I don't think it needs a NEWS entry, but let me know if you think otherwise.