### PR TITLE
Use tidyselect with get_dupes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
     snakecase (>= 0.9.2),
     magrittr,
     purrr,
-    rlang
+    rlang,
+    tidyselect
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 7.0.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,8 +26,7 @@ Imports:
     snakecase (>= 0.9.2),
     magrittr,
     purrr,
-    rlang,
-    tidyselect
+    rlang
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 7.0.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Authors@R: c(person("Sam", "Firke", email = "samuel.firke@gmail.com", role = c("
     person("Bill", "Denney", email = "wdenney@humanpredictions.com", role = "ctb"),
     person("Chris", "Haid", email = "chrishaid@gmail.com", role = "ctb"),
     person("Ryan", "Knight", email = "ryangknight@gmail.com", role = "ctb"),
-    person("Malte", "Grosser", email = "malte.grosser@gmail.com", role = "ctb"))
+    person("Malte", "Grosser", email = "malte.grosser@gmail.com", role = "ctb"),
+    person("Jonathan", "Zadra", email = "jonathan.zadra@sorensonimpact.com", role = "ctb"))
 Description: The main janitor functions can: perfectly format data.frame column
     names; provide quick counts of variable combinations (i.e., frequency
     tables and crosstabs); and isolate duplicate records. Other janitor functions
@@ -27,7 +28,7 @@ Imports:
     magrittr,
     purrr,
     rlang,
-    tidyselect
+    tidyselect (>= 1.0.0)
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 7.0.2
@@ -37,7 +38,5 @@ Suggests:
     rmarkdown,
     sf,
     tibble
-remotes:
-    r-lib/tidyselect
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,5 +37,7 @@ Suggests:
     rmarkdown,
     sf,
     tibble
+remotes:
+    r-lib/tidyselect
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# janitor 1.4.0
+
+## Major features
+
+* The function `get_dupes()` now uses tidyselect specification, the same as many tidyverse functions such as `dplyr::select()`.  This allows removal of columns to be considered using `-column_name` as well as the matching functions `starts_with()`, `ends_with()`, `contains()`, and `matches()`.
+
 # janitor 1.2.0.9000 (unreleased)
 
 ## Minor features

--- a/R/get_dupes.R
+++ b/R/get_dupes.R
@@ -3,47 +3,48 @@
 #' @description
 #' For hunting duplicate records during data cleaning.  Specify the data.frame and the variable combination to search for duplicates and get back the duplicated rows.
 #'
-#' @param dat the input data.frame.
-#' @param ... unquoted variable names to search for duplicates.
+#' @param dat The input data.frame.
+#' @param ... Unquoted variable names to search for duplicates. This takes a tidyselect specification.
 #' @return Returns a data.frame (actually a \code{tbl_df}) with the full records where the specified variables have duplicated values, as well as a variable \code{dupe_count} showing the number of rows sharing that combination of duplicated values.
 #' @export
 #' @examples
 #' get_dupes(mtcars, mpg, hp)
 #' # or called with the magrittr pipe %>% :
 #' mtcars %>% get_dupes(wt)
+#' # or using tidyselect:
+#' mtcars %>% get_dupes(weight = wt, starts_with("cy"))
 #'
 
 get_dupes <- function(dat, ...) {
-  uq_names <- as.list(substitute(list(...)))[-1L] # unquoted names for NSE calls, need quoted names separately for messages + warnings
-  df_name <- deparse(substitute(dat))
-
-  if (length(uq_names) == 0) { # if called on an entire data.frame with no specified variable names
+  
+  expr <- rlang::expr(c(...))
+  pos <- tidyselect::eval_select(expr, data = dat)
+  
+  names(dat)[pos] <- names(pos) #allows for renaming within get_dupes() consistent with select()
+  
+  if (rlang::dots_n(...) == 0) { # if no tidyselect variables are specified, check the whole data.frame
     var_names <- names(dat)
     nms <- rlang::syms(var_names)
     message("No variable names specified - using all columns.\n")
   } else {
-    nms <- rlang::quos(...) %>%
-      rlang::quos_auto_name()
-    var_names <- names(nms)
+    var_names <- names(pos)
+    nms <- rlang::syms(var_names)
   }
-
-  # check that each variable name provided is present in names(dat); if not, throw error
-  check_vars_in_df(dat, df_name, var_names)
+  
   dupe_count <- NULL # to appease NOTE for CRAN; does nothing.
-
+  
   # calculate counts to join back to main df
   counts <- dat %>%
-    dplyr::count(!!! nms)
-
-  names(counts)[ncol(counts)] <- "dupe_count"
+    dplyr::count(!!! nms, name = "dupe_count")
+  
   # join new count vector to main data.frame
   dupes <- suppressMessages(dplyr::inner_join(counts, dat))
-
+  
   dupes <- dupes %>%
     dplyr::filter(dupe_count > 1) %>%
     dplyr::ungroup() %>%
     dplyr::arrange(!!! nms)
-
+  
   # shorten error message for large data.frames
   if (length(var_names) > 10) {
     var_names <- c(var_names[1:9], paste("... and", length(var_names) - 9, "other variables"))
@@ -54,13 +55,4 @@ get_dupes <- function(dat, ...) {
   dupes
 }
 
-# takes a data.frame and vector of variable names, confirms that all var names match data.frame names
-check_vars_in_df <- function(dat, dat_name, names_vec) {
-  in_df <- unlist(lapply(names_vec, function(x) x %in% names(dat)))
-  if (sum(in_df) != length(in_df)) {
-    stop(paste0(
-      paste0("These variables do not match column names in ", dat_name, ": "),
-      paste(names_vec[!in_df], collapse = ", ")
-    ))
-  }
-}
+

--- a/man/get_dupes.Rd
+++ b/man/get_dupes.Rd
@@ -7,9 +7,9 @@
 get_dupes(dat, ...)
 }
 \arguments{
-\item{dat}{the input data.frame.}
+\item{dat}{The input data.frame.}
 
-\item{...}{unquoted variable names to search for duplicates.}
+\item{...}{Unquoted variable names to search for duplicates. This takes a tidyselect specification.}
 }
 \value{
 Returns a data.frame (actually a \code{tbl_df}) with the full records where the specified variables have duplicated values, as well as a variable \code{dupe_count} showing the number of rows sharing that combination of duplicated values.
@@ -21,5 +21,7 @@ For hunting duplicate records during data cleaning.  Specify the data.frame and 
 get_dupes(mtcars, mpg, hp)
 # or called with the magrittr pipe \%>\% :
 mtcars \%>\% get_dupes(wt)
+# or using tidyselect:
+mtcars \%>\% get_dupes(weight = wt, starts_with("cy"))
 
 }

--- a/tests/testthat/test-get-dupes.R
+++ b/tests/testthat/test-get-dupes.R
@@ -26,7 +26,7 @@ test_that("instances of no dupes throw correct messages, return empty df", {
 })
 
 test_that("incorrect variable names are handled", {
-  expect_error(get_dupes(mtcars, x), "These variables do not match column names in mtcars: x")
+  expect_error(get_dupes(mtcars, x))
 })
 
 test_that("works on variables with irregular names", {
@@ -36,4 +36,10 @@ test_that("works on variables with irregular names", {
     c(10, 13)
   ) # does it return the right-sized result?
   expect_is(badname_df %>% get_dupes(), "data.frame") # test for success, i.e., produces a data.frame (with 0 rows)
+})
+
+test_that("tidyselect specification matches exact specification", {
+  expect_equal(mtcars %>% get_dupes(contains("cy"), mpg), mtcars %>% get_dupes(cyl, mpg))
+  expect_equal(mtcars %>% get_dupes(mpg), mtcars %>% get_dupes(-c(cyl, disp, hp, drat, wt, qsec, vs, am ,gear, carb)))
+  expect_equal(suppressMessages(mtcars %>% select(cyl, wt) %>% get_dupes()), mtcars %>% select(cyl, wt) %>% get_dupes(everything()))
 })

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -187,7 +187,7 @@ test_that("grouped data.frame inputs are handled (#125)", {
 test_that("if called on non-existent vector, returns useful error message", {
   expect_error(tabyl(mtcars$moose), "object mtcars\\$moose not found")
   expect_error(tabyl(moose), "object 'moose' not found")
-  expect_error(mtcars %>% tabyl(moose), "object 'moose' not found")
+  expect_error(mtcars %>% tabyl(moose))
 })
 
 test_that("if called on data.frame with no or irregular columns specified, returns informative error message", {


### PR DESCRIPTION
Changed the method for selecting variables in the df to use `tidyselect`.  This allows negation, as well as `tidyselect helpers` like `starts_with()`, `ends_with()`, `contains()`, `matches()`, etc.

## Related Issue
#326 

## Example
`mtcars %>% get_dupes(weight = wt, starts_with("cy"))`

## Tests
Includes new tests:

```
test_that("tidyselect specification matches exact specification", {
  expect_equal(mtcars %>% get_dupes(contains("cy"), mpg), mtcars %>% get_dupes(cyl, mpg))
  expect_equal(mtcars %>% get_dupes(mpg), mtcars %>% get_dupes(-c(cyl, disp, hp, drat, wt, qsec, vs, am ,gear, carb)))
  expect_equal(suppressMessages(mtcars %>% select(cyl, wt) %>% get_dupes()), mtcars %>% select(cyl, wt) %>% get_dupes(everything()))
})
```

Also modifies test for specifying zero matching vars, as the old function for doing so was removed.  tidyselect now throws its own error if nothing matches for exact specification.  

NOTE however that using a tidyselect helper that doesn't catch anything will not produce any error or message.
