### PR TITLE
Fix compatability with tibble 3.0.0 and R 4.0.0

### DIFF
--- a/R/adorn_title.R
+++ b/R/adorn_title.R
@@ -71,7 +71,10 @@ adorn_title <- function(dat, placement = "top", row_name, col_name) {
       dat[, ] <- lapply(dat[, ], as.character) # to handle factors, problematic in first column and at bind_rows.
       # Can't use mutate_all b/c it strips attributes
       top <- dat[1, ]
-      top[1, ] <- names(top)
+      
+      for(i in seq_len(ncol(top))){
+        top[1, i] <- names(top)[i]
+      }
 
       out <- dplyr::bind_rows(top, dat)
       out <- stats::setNames(out, c("", col_var, rep("", ncol(out) - 2)))

--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -52,6 +52,7 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "T
       # to allow binding of "Total" and "-" onto date, factor columns 
       not_numerics <- vapply(dat, function(x) !is.numeric(x), NA)
       dat[not_numerics] <- lapply(dat[not_numerics], as.character)
+      dat[[1]] <- as.character(dat[[1]])
       
       
       # creates the totals row to be appended

--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -209,6 +209,7 @@ tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TR
   if (is.factor(tabl[[2]])) {
     levels(tabl[[2]]) <- c(levels(tabl[[2]]), "NA_")
   }
+  tabl[2] <- as.character(tabl[[2]])
   tabl[2][is.na(tabl[2])] <- "NA_"
   result <- tabl %>%
     tidyr::spread(!! var2, "n", fill = 0)

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -7,7 +7,8 @@ library(dplyr)
 
 dat <- data.frame(
   a = c(rep(c("big", "small", "big"), 3)),
-  b = c(1:3, 1:3, 1, 1, 1)
+  b = c(1:3, 1:3, 1, 1, 1),
+  stringsAsFactors = TRUE
 )
 ct <- dat %>%
   tabyl(a, b)

--- a/tests/testthat/test-clean-NAs.R
+++ b/tests/testthat/test-clean-NAs.R
@@ -5,7 +5,8 @@ context("recoding of string NA values into NAs")
 
 test_df <- data.frame(
   v1 = c(1, NA, 3),
-  v_fac = c("a", "a", "b")
+  v_fac = c("a", "a", "b"),
+  stringsAsFactors = TRUE
 )
 test_df$v2 <- c("NA", "#NAME?", "n/a") # this one will be character, not factor
 

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -225,7 +225,8 @@ test_that("show_missing_levels parameter works", {
     list(lvl1 = data.frame(
       a = c("hi", "lo"),
       big = c(0, 0),
-      small = c(1, 0)
+      small = c(1, 0),
+      stringsAsFactors = TRUE
     ) %>% as_tabyl(2, "a", "b"))
   )
   expect_equal(


### PR DESCRIPTION
No change to functionality.

For tibble 3.0.0, had to update a few functions where I was lazily casting by say, binding a character with a numeric, and that now must be made explicit.

For R 4.0.0 I only had to fix tests, by saying `stringsAsFactors = TRUE`.

closes #333.  Though it still need to go to CRAN.