### PR TITLE
character columns in tabyl input to adorn_ns are ignored

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,10 @@
 
 ## Major features
 
-* The function `get_dupes()` now uses tidyselect specification, the same as many tidyverse functions such as `dplyr::select()`.  This allows removal of columns to be considered using `-column_name` as well as the matching functions `starts_with()`, `ends_with()`, `contains()`, and `matches()`.
+* The variables considered by the function `get_dupes()` can be specified using the select helper functions from `tidyselect`.  This includes `-column_name` to omit a variable as well as the matching functions `starts_with()`, `ends_with()`, `contains()`, and `matches()`.  See `?tidyselect::select_helpers` for more (#326, thanks to **@jzadra** for suggesting and implementing).
+
+
+* The new function `signif_half_up()` rounds a numeric vector to the specified number of significant digits with halves rounded up (#314, thanks to **@khueyama** for suggesting and implementing). 
 
 ## Minor features
 
@@ -10,12 +13,15 @@
 
 * `row_to_names()` will now work on matrix input (#320, thanks to **@billdenney** for suggesting and implementing
 
-* The new function `signif_half_up()` rounds a numeric vector to the specified number of significant digits with halves rounded up (#314, thanks to **@khueyama** for suggesting and implementing). 
 
 ## Bug fixes
 
-* The `name` argument to `adorn_totals()` is correctly applied to 3-way tabyls (#306)  Thanks to **@jzadra** for reporting.
+* `adorn_ns()` doesn't append anything to character columns when called on a data.frame resulting from a call to `adorn_percentages()`.  (#195).
+
+* The `name` argument to `adorn_totals()` is correctly applied to 3-way tabyls (#306) (thanks to **@jzadra** for reporting).
+
 * `remove_constant()` works correctly with tibbles in addition to data.frames and matrices which already worked (thanks to **@billdenney** for implementing).
+
 
 # janitor 1.2.1 (2020-01-22)
 

--- a/R/adorn_ns.R
+++ b/R/adorn_ns.R
@@ -72,14 +72,16 @@ adorn_ns <- function(dat, position = "rear", ns = attr(dat, "core")) {
     
     # Reset columns that were character in the default core attribute, #195
     # Eventually this would ideally be supplemented with or replaced by giving users the option to select cols
-    if(!ns_provided){
+
+    if(!ns_provided) { # leave character cols untouched if user didn't supply Ns
       non_numeric_cols <- which(vapply(ns, purrr::negate(is.numeric), logical(1)))
+    } else { # if user supplied custom Ns, all columns beyond the first are adjusted.
+      non_numeric_cols <- numeric()
+    }
       non_numeric_cols <- unique(c(1, non_numeric_cols)) # always don't-append first column
       for(i in non_numeric_cols){
           result[[i]] <- dat[[i]]
       }
-    }
-    
     result
   }
 }

--- a/R/get_dupes.R
+++ b/R/get_dupes.R
@@ -9,9 +9,11 @@
 #' @export
 #' @examples
 #' get_dupes(mtcars, mpg, hp)
+#' 
 #' # or called with the magrittr pipe %>% :
 #' mtcars %>% get_dupes(wt)
-#' # or using tidyselect:
+#' 
+#' # You can use tidyselect helpers to specify variables:
 #' mtcars %>% get_dupes(weight = wt, starts_with("cy"))
 #'
 

--- a/man/get_dupes.Rd
+++ b/man/get_dupes.Rd
@@ -19,9 +19,11 @@ For hunting duplicate records during data cleaning.  Specify the data.frame and 
 }
 \examples{
 get_dupes(mtcars, mpg, hp)
+
 # or called with the magrittr pipe \%>\% :
 mtcars \%>\% get_dupes(wt)
-# or using tidyselect:
+
+# You can use tidyselect helpers to specify variables:
 mtcars \%>\% get_dupes(weight = wt, starts_with("cy"))
 
 }

--- a/tests/testthat/test-adorn-ns.R
+++ b/tests/testthat/test-adorn-ns.R
@@ -5,7 +5,7 @@ context("adorn_ns()")
 
 library(dplyr)
 
-source_an <- data_frame(
+source_an <- tibble(
   x = c(rep("a", 500), "b", "b", "c", "d"),
   y = rep(c(0, 0, 0, 0, 0, 1), 84)
 ) %>%
@@ -158,4 +158,20 @@ test_that("automatically invokes purrr::map when called on a 3-way tabyl", {
 
 test_that("non-data.frame inputs are handled", {
   expect_error(adorn_ns(1:5), "adorn_ns() must be called on a data.frame or list of data.frames", fixed = TRUE)
+})
+
+test_that("multiple character columns in a tabyl are left untouched",{
+  small_with_char <- data.frame(
+    x = letters[1:2],
+    a = 1:2,
+    b = 3:4,
+    text = "text",
+    stringsAsFactors = FALSE
+  )
+ expect_equal(
+   small_with_char %>%
+    adorn_percentages() %>%
+     pull(text),
+   c("text", "text")
+  )
 })


### PR DESCRIPTION
Closes #195.

This now produces the correct result, where "homeworld" is not appended to itself:
```
starwars %>%
  count(gender, homeworld) %>%
  slice(1:5) %>%
  adorn_percentages("col") %>%
  adorn_pct_formatting() %>% 
  adorn_ns()
#>  gender homeworld         n
#>  female  Alderaan 14.3% (1)
#>  female Chandrila 14.3% (1)
#>  female Coruscant 28.6% (2)
#>  female    Kamino 14.3% (1)
#>  female    Mirial 28.6% (2)
```