### PR TITLE
Add case argument to clean_names.sf

### DIFF
--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -78,7 +78,7 @@ clean_names.sf <- function(dat, case = c(
   # identify ending column index to clean
   n_cols <- length(dat)-1 
   # clean all but last column
-  sf_cleaned <- make_clean_names(sf_names[1:n_cols]) 
+  sf_cleaned <- make_clean_names(sf_names[1:n_cols], case) 
   # rename original df
   names(dat)[1:n_cols] <- sf_cleaned 
   

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -162,5 +162,81 @@ test_that("Names are cleaned appropriately", {
   expect_equal(names(clean)[19], "jan2009sales") # no separator around number-word boundary if not existing already
   expect_equal(names(clean)[20], "jan_2009_sales") # yes separator around number-word boundary if it existed
   
-  expect_is(clean, "sf", info="Returns a data.frame")
+  expect_is(clean, "sf", info="Returns a sf data.frame")
+})
+
+
+test_that("Tests for cases beyond default snake for sf objects", {
+  
+  
+  test_df <- data.frame(matrix(ncol = 22) %>% as.data.frame())
+  
+  names(test_df) <- c(
+    "sp ace", "repeated", "a**^@", "%", "*", "!",
+    "d(!)9", "REPEATED", "can\"'t", "hi_`there`", "  leading spaces",
+    "€", "ação", "Farœ", "a b c d e f", "testCamelCase", "!leadingpunct",
+    "average # of days", "jan2009sales", "jan 2009 sales", "long", "lat"
+  )
+  
+  test_df["long"] <- -80
+  test_df["lat"] <- 40
+  
+  test_df <- st_as_sf(test_df, coords = c("long", "lat"))
+  names(test_df)[21] <- "geometry"
+  st_geometry(test_df) <- "geometry"
+  
+  
+  
+  expect_equal(
+    names(clean_names(test_df, "small_camel")),
+    c(
+      "spAce", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2",
+      "cant", "hiThere", "leadingSpaces", "x_3", "acao", "faroe", "aBCDEF", "testCamelCase", "leadingpunct", "averageNumberOfDays", "jan2009Sales", "jan2009Sales_2", "geometry"
+    )
+  )
+  expect_equal(
+    names(clean_names(test_df, "big_camel")),
+    c(
+      "SpAce", "Repeated", "A", "Percent", "X", "X_2", "D9", "Repeated_2",
+      "Cant", "HiThere", "LeadingSpaces", "X_3", "Acao", "Faroe", "ABCDEF", "TestCamelCase", "Leadingpunct", "AverageNumberOfDays", "Jan2009Sales", "Jan2009Sales_2", "geometry"
+    )
+  )
+  expect_equal(
+    names(clean_names(test_df, "all_caps")),
+    c(
+      "SP_ACE", "REPEATED", "A", "PERCENT", "X", "X_2", "D_9", "REPEATED_2",
+      "CANT", "HI_THERE", "LEADING_SPACES", "X_3", "ACAO", "FAROE", "A_B_C_D_E_F", "TEST_CAMEL_CASE", "LEADINGPUNCT", "AVERAGE_NUMBER_OF_DAYS", "JAN2009SALES", "JAN_2009_SALES", "geometry"
+    )
+  )
+  expect_equal(
+    names(clean_names(test_df, "lower_upper")),
+    c(
+      "spACE", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2",
+      "cant", "hiTHERE", "leadingSPACES", "x_3", "acao", "faroe", "aBcDeF", "testCAMELcase", "leadingpunct", "averageNUMBERofDAYS", "jan2009SALES", "jan2009SALES_2", "geometry"
+    )
+  )
+  expect_equal(
+    names(clean_names(test_df, "upper_lower")),
+    c(
+      "SPace", "REPEATED", "A", "PERCENT", "X", "X_2", "D9", "REPEATED_2",
+      "CANT", "HIthere", "LEADINGspaces", "X_3", "ACAO", "FAROE", "AbCdEf", "TESTcamelCASE", "LEADINGPUNCT", "AVERAGEnumberOFdays", "JAN2009sales", "JAN2009sales_2", "geometry"
+    )
+  )
+  expect_equal(
+    names(clean_names(test_df, "none")),
+    c(
+      "sp_ace", "repeated", "a", "percent", "X", "X_2", "d_9", "REPEATED",
+      "cant", "hi_there", "leading_spaces", "X_3", "acao", "Faroe", "a_b_c_d_e_f", 
+      "testCamelCase", "leadingpunct", "average_number_of_days", 
+      "jan2009sales", "jan_2009_sales", "geometry"
+    )
+  )
+  expect_equal(
+    names(clean_names(test_df, "old_janitor")),
+    c(
+      "sp_ace", "repeated", "a", "percent", "x", "x_2", "d_9", "repeated_2",
+      "cant", "hi_there", "leading_spaces", "x_3", "ação", "farœ",
+      "a_b_c_d_e_f", "testcamelcase", "x_leadingpunct", "average_of_days", "jan2009sales", "jan_2009_sales", "geometry"
+    )
+  )
 })


### PR DESCRIPTION
## Description
Pass 'case' argument through to clean_names sf method.
Add test cases based on the regular data.frame method

## Related Issue
Issue at: #339
Related (extends) to #247 

## Example

This used to ignore the 'all_caps' argument
``` r
  library(janitor)
test_df = data.frame('column' = 'data')
test_df["long"] <- -80
test_df["lat"] <- 40

test_df <- sf::st_as_sf(test_df, coords = c("long", "lat"))

clean_names(test_df, 'all_caps')
#> Simple feature collection with 1 feature and 1 field
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: -80 ymin: 40 xmax: -80 ymax: 40
#> epsg (SRID):    NA
#> proj4string:    NA
#>   COLUMN       geometry
#> 1   data POINT (-80 40)
```


