### PR TITLE
get_dupes() grouped data error fix

### DIFF
--- a/R/get_dupes.R
+++ b/R/get_dupes.R
@@ -30,7 +30,10 @@ get_dupes <- function(dat, ...) {
   if(is_grouped) {
     dat_groups <- dplyr::group_vars(dat)
     dat <- dat %>% dplyr::ungroup()
-    message(paste0("Data is grouped by [", paste(dat_groups, collapse = "|"), "]. Note that get_dupes() is not group aware and does not limit duplicate detection to within-groups, but rather checks over the entire data frame. However grouping structure is preserved."))
+    if(getOption("get_dupes.grouped_warning",TRUE) & interactive()) {
+      message(paste0("Data is grouped by [", paste(dat_groups, collapse = "|"), "]. Note that get_dupes() is not group aware and does not limit duplicate detection to within-groups, but rather checks over the entire data frame. However grouping structure is preserved.\nThis message is shown once per session and may be disabled by setting options(\"get_dupes.grouped_warning\" = FALSE)."))
+      options("get_dupes.grouped_warning" = FALSE)
+    }
   }
   
   if (rlang::dots_n(...) == 0) { # if no tidyselect variables are specified, check the whole data.frame

--- a/R/get_dupes.R
+++ b/R/get_dupes.R
@@ -31,8 +31,8 @@ get_dupes <- function(dat, ...) {
     dat_groups <- dplyr::group_vars(dat)
     dat <- dat %>% dplyr::ungroup()
     if(getOption("get_dupes.grouped_warning",TRUE) & interactive()) {
-      message(paste0("Data is grouped by [", paste(dat_groups, collapse = "|"), "]. Note that get_dupes() is not group aware and does not limit duplicate detection to within-groups, but rather checks over the entire data frame. However grouping structure is preserved.\nThis message is shown once per session and may be disabled by setting options(\"get_dupes.grouped_warning\" = FALSE)."))
-      options("get_dupes.grouped_warning" = FALSE)
+      message(paste0("Data is grouped by [", paste(dat_groups, collapse = "|"), "]. Note that get_dupes() is not group aware and does not limit duplicate detection to within-groups, but rather checks over the entire data frame. However grouping structure is preserved.\nThis message is shown once per session and may be disabled by setting options(\"get_dupes.grouped_warning\" = FALSE).")) #nocov
+      options("get_dupes.grouped_warning" = FALSE) #nocov
     }
   }
   

--- a/R/get_dupes.R
+++ b/R/get_dupes.R
@@ -65,7 +65,7 @@ get_dupes <- function(dat, ...) {
   }
   
   #Reapply groups if dat was grouped
-  if(is_grouped) dupes <- dupes %>% dplyr::group_by(!!!syms(dat_groups))
+  if(is_grouped) dupes <- dupes %>% dplyr::group_by(!!!rlang::syms(dat_groups))
   
   return(dupes)
 }

--- a/tests/testthat/test-get-dupes.R
+++ b/tests/testthat/test-get-dupes.R
@@ -49,4 +49,5 @@ test_that("grouped and ungrouped data is handled correctly", {
                mtcars %>% group_by(carb, cyl) %>% group_vars())
   expect_equal(suppressMessages(mtcars %>% group_by(carb, cyl) %>% get_dupes(mpg, carb) %>% ungroup()),
                mtcars %>% get_dupes(mpg, carb))
+  expect_message(mtcars %>% group_by(carb, cyl) %>% get_dupes())
 })

--- a/tests/testthat/test-get-dupes.R
+++ b/tests/testthat/test-get-dupes.R
@@ -49,5 +49,4 @@ test_that("grouped and ungrouped data is handled correctly", {
                mtcars %>% group_by(carb, cyl) %>% group_vars())
   expect_equal(suppressMessages(mtcars %>% group_by(carb, cyl) %>% get_dupes(mpg, carb) %>% ungroup()),
                mtcars %>% get_dupes(mpg, carb))
-  expect_message(mtcars %>% group_by(carb, cyl) %>% get_dupes())
 })

--- a/tests/testthat/test-get-dupes.R
+++ b/tests/testthat/test-get-dupes.R
@@ -43,3 +43,10 @@ test_that("tidyselect specification matches exact specification", {
   expect_equal(mtcars %>% get_dupes(mpg), mtcars %>% get_dupes(-c(cyl, disp, hp, drat, wt, qsec, vs, am ,gear, carb)))
   expect_equal(suppressMessages(mtcars %>% select(cyl, wt) %>% get_dupes()), mtcars %>% select(cyl, wt) %>% get_dupes(everything()))
 })
+
+test_that("grouped and ungrouped data is handled correctly", {
+  expect_equal(suppressMessages(mtcars %>% group_by(carb, cyl) %>% get_dupes(mpg, carb)) %>% group_vars(), 
+               mtcars %>% group_by(carb, cyl) %>% group_vars())
+  expect_equal(suppressMessages(mtcars %>% group_by(carb, cyl) %>% get_dupes(mpg, carb) %>% ungroup()),
+               mtcars %>% get_dupes(mpg, carb))
+})


### PR DESCRIPTION
## Description

If data is grouped:
1. Saves the grouping structure and then removes it before checking for duplicates. 
2. One warning per session is issued notifying user that get_dupes() isn't checking within groups but rather over the whole data set, however will still return an object with the same grouping structure.
3. Groups are reapplied before returning dupes.

Added tests that check that

1. The grouping structure of the original data is the same as the result.
2. The output for grouped data is the same as the output for ungrouped data other than the grouping structure.

## Related Issue
Addresses #329.

## Example
x <- mtcars %>% group_by(cyl, gear)
get_dupes(x)
