### PR TITLE
adapt tests to dplyr 1.0.0

### DIFF
--- a/tests/testthat/test-adorn-crosstab.R
+++ b/tests/testthat/test-adorn-crosstab.R
@@ -75,7 +75,7 @@ test_that("digits parameter is correct", {
 
 test_that("show_n can suppress Ns, digits parameter is correct", {
   digits3 <- suppressWarnings(mtcars %>% tabyl(carb, gear) %>% adorn_crosstab(denom = "row", digits = 3, show_n = FALSE))
-  expect_equal(digits3, data.frame(
+  expect_equivalent(digits3, data.frame(
     carb = c(1:4, 6, "8"),
     `3` = c("42.857%", "40.000%", "100.000%", "50.000%", "0.000%", "0.000%"),
     `4` = c("57.143%", "40.000%", "0.000%", "40.000%", "0.000%", "0.000%"),

--- a/tests/testthat/test-convert_to_date.R
+++ b/tests/testthat/test-convert_to_date.R
@@ -30,7 +30,7 @@ test_that("convert_date works", {
     as.Date("2009-07-06")
   )
   expect_equal(
-    convert_to_date(as.POSIXct("2009-07-06")),
+    convert_to_date(as.POSIXct("2009-07-06", tz = "UTC")),
     as.Date("2009-07-06")
   )
   expect_equal(


### PR DESCRIPTION
Minor changes to the tests so that the package passes against `dplyr` 1.0.0