### PR TITLE
Update round_half_up.R

### DIFF
--- a/R/round_half_up.R
+++ b/R/round_half_up.R
@@ -18,7 +18,6 @@ round_half_up <- function(x, digits = 0) {
   posneg <- sign(x)
   z <- abs(x) * 10 ^ digits
   z <- z + 0.5
-  z <- trunc(z)
   z <- z / 10 ^ digits
   z * posneg
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In response to issue #396. Removed trunc() function from round_half_up(). The trunc() function was returning a rounded down value. round_half_up(2436.845, 2) now returns 2436.85.

## Related Issue
<!--- Please note what issue(s) your pull request addresses,
e.g., "fixes #150".  If there's not an issue related to your
pull request, please create one so we can align on the problem
being addressed. -->

In response to issue #396. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

round_half_up(2436.845, 2) now returns 2436.85.

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
