### PR TITLE
Address issue #396

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+* Fixed rounding issue in round_half_up() function (#396, thanks to @JJSteph)
+
 * Warnings for incomplete argument names are fixed (fix #367, thanks to @pabecerra for reporting and @billdenney for fixing)
 
 * 3-way tabyls with factors have columns and rows sorted in the correct order, by factor level (#379).

--- a/R/round_half_up.R
+++ b/R/round_half_up.R
@@ -17,7 +17,7 @@
 round_half_up <- function(x, digits = 0) {
   posneg <- sign(x)
   z <- abs(x) * 10 ^ digits
-  z <- z + 0.5
+  z <- z + 0.5 + sqrt(.Machine$double.eps)
   z <- trunc(z)
   z <- z / 10 ^ digits
   z * posneg

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -10,4 +10,5 @@ test_that("round_half_up works", {
   expect_equal(round_half_up(0.5, 0), 1)
   expect_equal(round_half_up(1.125, 2), 1.13)
   expect_equal(round_half_up(1.135, 2), 1.14)
+  expect_equal(round_half_up(2436.845, 2), 2436.85)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Accounted for precision error in rounding. 

## Related Issue
<!--- Please note what issue(s) your pull request addresses,
e.g., "fixes #150".  If there's not an issue related to your
pull request, please create one so we can align on the problem
being addressed. -->

Should fix issue #396.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

> round_half_up(2436.845, 2)
[1] 2436.85

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

> round_half_up(123.456,1)
[1] 123.5
> round_half_up(123.456,2)
[1] 123.46
> round_half_up(123.456,3)
[1] 123.456

> round_half_up(-123.456,1)
[1] -123.5
> round_half_up(-123.456,2)
[1] -123.46
> round_half_up(-123.456,3)
[1] -123.456