### PR TITLE
changed adorn_totals to take where = both argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # janitor 2.0.1.9000 (unreleased)
 
+## New features
+
+* The `adorn_totals()` function now takes the value of `"both"` for the `where` argument.  That is, `adorn_totals("both")` is a shorter version of `adorn_totals(c("col", "row"))`.  (#362, thanks to **@svgsstats** for implementing and **@sfd99** for suggesting).
+
+
 ## Bug fixes
 
 * Fixed rounding issue in round_half_up() function (#396, thanks to @JJSteph)

--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -18,6 +18,9 @@
 
 
 adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "Total", ...) {
+  if(where=="both"){
+    where=c("row","col");
+  }
   # if input is a list, call purrr::map to recursively apply this function to each data.frame
   if (is.list(dat) && !is.data.frame(dat)) {
     purrr::map(dat, adorn_totals, where, fill, na.rm, name)

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -70,6 +70,23 @@ test_that("totals row and col produce correct results when called together", {
   )
 })
 
+test_that("totals where='both' produce equivalent results to c('row','col')", {
+  expect_equal(
+    ct %>%
+      adorn_totals("both") %>%
+      untabyl(),
+    data.frame(
+      a = c("big", "small", "Total"),
+      `1` = c(4, 1, 5),
+      `2` = c(0, 2, 2),
+      `3` = c(2, 0, 2),
+      Total = c(6, 3, 9),
+      check.names = FALSE,
+      stringsAsFactors = FALSE
+    )
+  )
+})
+
 test_that("order doesn't matter when row and col are called together", {
   expect_equal(
     ct %>%


### PR DESCRIPTION
Changed the adorn_totals() function so that where = "both" is equivalent to where = c("row","col")

Added a test as well.

## Description
Just added a simple conditional to the adorn_totals() function.  

I didn't update the NEWS.md file because I was unsure of the way that should get done.

## Related Issue
improvement as per #362


## Example
ct %>% tabyl(where="both")

