### PR TITLE
Added option to pass NA to fill argument of adorn_totals to preserve column types

### DIFF
--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -5,7 +5,7 @@
 #'
 #' @param dat an input data.frame with at least one numeric column.  If given a list of data.frames, this function will apply itself to each data.frame in the list (designed for 3-way \code{tabyl} lists).
 #' @param where one of "row", "col", or \code{c("row", "col")}
-#' @param fill if there are non-numeric columns, what string should fill the bottom row of those columns?
+#' @param fill if there are non-numeric columns, what should fill the bottom row of those columns? If a string, relevant columns will be coerced to character. If `NA` then column types are preserved. 
 #' @param na.rm should missing values (including NaN) be omitted from the calculations?
 #' @param name name of the totals column or row 
 #' @param ... columns to total.  This takes a tidyselect specification.  By default, all numeric columns (besides the initial column, if numeric) are included in the totals, but this allows you to manually specify which columns should be included, for use on a data.frame that does not result from a call to \code{tabyl}. 
@@ -73,14 +73,46 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "T
         if (is.numeric(a_col)) { # can't do this with if_else because it doesn't like the sum() of a character vector, even if that clause is not reached
           sum(a_col, na.rm = na_rm)
         } else {
-          fill
+          if(!is.character(fill)) { #if fill isn't a character string, use NA consistent with data types
+            switch(typeof(a_col),
+                   "character" = NA_character_,
+                   "integer" = NA_integer_,
+                   "double" = NA_real_,
+                   "complex" = NA_complex_,
+                   NA)
+          } else {
+            fill # otherwise just use the string provided
+          }
         }
       }
-
-      col_totals <- purrr::map_df(dat, col_sum)
-      not_totaled_cols <- setdiff(1:length(col_totals), cols_to_total)
-      col_totals[not_totaled_cols] <- fill # reset numeric columns that weren't to be totaled
-      dat[not_totaled_cols] <- lapply(dat[not_totaled_cols], as.character) # type compatibility for bind_rows
+      
+      if(is.character(fill)) { # if fill is a string, keep original implementation
+        col_totals <- purrr::map_df(dat, col_sum)
+        not_totaled_cols <- setdiff(1:length(col_totals), cols_to_total)
+        col_totals[not_totaled_cols] <- fill # reset numeric columns that weren't to be totaled
+        dat[not_totaled_cols] <- lapply(dat[not_totaled_cols], as.character) # type compatibility for bind_rows
+      } else { 
+        
+        cols_idx <- seq_along(dat) # get col indexes
+        names(cols_idx) <- names(dat) # name them using dat names
+        
+        col_totals <- purrr::map_df(cols_idx, function(i) {
+          if(is.numeric(dat[[i]]) && !i %in% cols_to_total) { # check if numeric and not to be totaled
+            switch(typeof(dat[[i]]), # and set to NA
+                   "integer" = NA_integer_,
+                   "double" = NA_real_,
+                   NA)
+          } else { # otherwise run col_sum on the rest
+            col_sum(dat[[i]])
+          }
+        })
+        
+        if(!is.numeric(dat[[1]])) { # convert first col to character so that name can be appended
+          dat[[1]] <- as.character(dat[[1]])
+          col_totals[[1]] <- as.character(col_totals[[1]])
+        }
+        
+      }
       
       if(! 1 %in% cols_to_total){ # give users the option to total the first column??  Up to them I guess
         col_totals[1, 1] <- name # replace first column value with name argument

--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -107,7 +107,7 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "T
           }
         })
         
-        if(!is.numeric(dat[[1]])) { # convert first col to character so that name can be appended
+        if(!is.character(dat[[1]]) && !1 %in% cols_to_total) { # convert first col to character so that name can be appended
           dat[[1]] <- as.character(dat[[1]])
           col_totals[[1]] <- as.character(col_totals[[1]])
         }

--- a/man/adorn_totals.Rd
+++ b/man/adorn_totals.Rd
@@ -11,7 +11,7 @@ adorn_totals(dat, where = "row", fill = "-", na.rm = TRUE, name = "Total", ...)
 
 \item{where}{one of "row", "col", or \code{c("row", "col")}}
 
-\item{fill}{if there are non-numeric columns, what string should fill the bottom row of those columns?}
+\item{fill}{if there are non-numeric columns, what should fill the bottom row of those columns? If a string, relevant columns will be coerced to character. If `NA` then column types are preserved.}
 
 \item{na.rm}{should missing values (including NaN) be omitted from the calculations?}
 

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -350,3 +350,37 @@ test_that("tidyselecting works", {
       as.data.frame()
   )
 })
+
+test_that("supplying NA to fill preserves column types", {
+  
+  test_df <- data.frame(
+    a = c("hi", "low", "med"),
+    b = factor(c("big", "small", "regular")),
+    c = c(as.Date("2000-01-01"), as.Date("2000-01-02"), as.Date("2000-01-03")),
+    d = 1:3,
+    e = 4:6,
+    f = c(TRUE, FALSE, TRUE),
+    g = c(7.2, 8.2, 9.2),
+    stringsAsFactors = FALSE
+  )
+  
+  out <- adorn_totals(test_df, fill = NA)
+  
+  # expect types to be preserved
+  expect_is(out[["a"]], "character") 
+  expect_is(out[["b"]], "factor")
+  expect_is(out[["c"]], "Date")
+  expect_is(out[["f"]], "logical")
+  # expect NAs in total rows for non-numerics
+  expect_true(is.na(out[4,"b"]))
+  expect_true(is.na(out[4,"c"]))
+  expect_true(is.na(out[4,"f"]))
+  # test values of totals
+  expect_equal(out[4,"a"], "Total")
+  expect_equal(out[4,"d"], 6)
+  expect_equal(out[4,"e"], 15)
+  expect_equal(out[4,"g"], 25,6)
+  # expect original df intact
+  expect_equivalent(test_df, out[1:3,])
+  
+})

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -379,8 +379,36 @@ test_that("supplying NA to fill preserves column types", {
   expect_equal(out[4,"a"], "Total")
   expect_equal(out[4,"d"], 6)
   expect_equal(out[4,"e"], 15)
-  expect_equal(out[4,"g"], 25,6)
+  expect_equal(out[4,"g"], 24.6)
   # expect original df intact
   expect_equivalent(test_df, out[1:3,])
+  
+})
+
+test_that("supplying NA as fill still works with non-character first col and numeric non-totaled cols", {
+  
+  test_df <- data.frame(
+    a = factor(c("hi", "low", "med")),
+    b = factor(c("big", "small", "regular")),
+    c = c(as.Date("2000-01-01"), as.Date("2000-01-02"), as.Date("2000-01-03")),
+    d = 1:3,
+    e = 4:6,
+    f = c(TRUE, FALSE, TRUE),
+    g = c(7.2, 8.2, 9.2),
+    stringsAsFactors = FALSE
+  )
+  
+  out <- adorn_totals(test_df, 
+                      where = "row", 
+                      fill = NA,
+                      na.rm = TRUE,
+                      name = "Total",
+                      d, e)
+  
+  expect_equal(out[["a"]], c("hi", "low", "med", "Total"))
+  expect_equal(out[["g"]], c(7.2, 8.2, 9.2, NA_real_))
+  expect_equal(out[4,"d"], 6)
+  expect_equal(out[4,"e"], 15)
+  expect_equivalent(test_df[1:3, 2:7], out[1:3,2:7])
   
 })

--- a/tests/testthat/test-add-totals.R
+++ b/tests/testthat/test-add-totals.R
@@ -371,6 +371,8 @@ test_that("supplying NA to fill preserves column types", {
   expect_is(out[["b"]], "factor")
   expect_is(out[["c"]], "Date")
   expect_is(out[["f"]], "logical")
+  # expect factor levels to be preserved
+  expect_equal(levels(out[["b"]]), levels(test_df[["b"]]))
   # expect NAs in total rows for non-numerics
   expect_true(is.na(out[4,"b"]))
   expect_true(is.na(out[4,"c"]))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have implemented a type check in the `col_sum` function in `adorn_totals` such that the function checks the data type of a column and uses the relevant `NA` variant for the total column. This only happens if the user does not supply a string (e.g. "-" as the fill value - I have kept this as the default). This also required some changes in the subsequent `purrr::map_df` call, but I have kept the original implementation as the default behavior. 

I have also updated the documentation to reflect this change and written a unit test in the `test-add-totals.R` script. Note that I have **not** updated the NEWS file as I don't know if there is a preferred wording/style so will leave that up to the maintainer.

## Related Issue
<!--- Please note what issue(s) your pull request addresses,
e.g., "fixes #150".  If there's not an issue related to your
pull request, please create one so we can align on the problem
being addressed. -->
fixes #298. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
test_df <- data.frame(
    a = c("hi", "low", "med"),
    b = factor(c("big", "small", "regular")),
    c = c(as.Date("2000-01-01"), as.Date("2000-01-02"), as.Date("2000-01-03")),
    d = 1:3,
    e = 4:6,
    f = c(TRUE, FALSE, TRUE),
    g = c(7.2, 8.2, 9.2),
    stringsAsFactors = FALSE
  )
  
  out <- adorn_totals(test_df, fill = NA)
```
This produces a `tabyl` with a total row that preserves the data types for each column:
```
out

     a       b          c d  e     f    g
    hi     big 2000-01-01 1  4  TRUE  7.2
   low   small 2000-01-02 2  5 FALSE  8.2
   med regular 2000-01-03 3  6  TRUE  9.2
 Total    <NA>       <NA> 6 15    NA 24.6

str(out)

Classes ‘tabyl’ and 'data.frame':	4 obs. of  7 variables:
 $ a: chr  "hi" "low" "med" "Total"
 $ b: Factor w/ 3 levels "big","regular",..: 1 3 2 NA
 $ c: Date, format:  ...
 $ d: int  1 2 3 6
 $ e: int  4 5 6 15
 $ f: logi  TRUE FALSE TRUE NA
 $ g: num  7.2 8.2 9.2 24.6
 - attr(*, "core")='data.frame':	3 obs. of  7 variables:
  ..$ a: chr [1:3] "hi" "low" "med"
  ..$ b: Factor w/ 3 levels "big","regular",..: 1 3 2
  ..$ c: Date[1:3], format:  ...
  ..$ d: int [1:3] 1 2 3
  ..$ e: int [1:3] 4 5 6
  ..$ f: logi [1:3] TRUE FALSE TRUE
  ..$ g: num [1:3] 7.2 8.2 9.2
 - attr(*, "tabyl_type")= chr "two_way"
 - attr(*, "totals")= chr "row"
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
