### PR TITLE
Warn for dates before 1 in `excel_numeric_to_date()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## Minor features
 
-* `excel_numeric_to_date()` now warns when times are converted to `NA` due to hours that do not exist because of daylight savings time.  (fix #420, thanks **@Geomorph2** for reporting and **@billdenney** for fixing)
+* `excel_numeric_to_date()` now warns when times are converted to `NA` due to hours that do not exist because of daylight savings time (fix #420, thanks **@Geomorph2** for reporting and **@billdenney** for fixing).  It also warns when inputs are not positive, since Excel only supports values down to 1 (fix #423).
 
 # janitor 2.1.0 (2021-01-05)
 

--- a/R/excel_dates.R
+++ b/R/excel_dates.R
@@ -72,7 +72,7 @@ excel_numeric_to_date <- function(date_num, date_system = "modern", include_time
   mask_excel_leap_day_bug <- !is.na(date_num_days) & floor(date_num_days) == 60
   mask_before_excel_leap_day_bug <- !is.na(date_num_days) & floor(date_num_days) < 60
   date_num_days[mask_excel_leap_day_bug] <- NA_real_
-  if (any(date_num_days < 1)) {
+  if (any(!is.na(date_num_days) & (date_num_days < 1))) {
     warning("Only `date_num` >= 1 are valid in Excel, creating an earlier date than Excel supports.")
   }
   date_num_days[mask_before_excel_leap_day_bug] <- date_num_days[mask_before_excel_leap_day_bug] + 1

--- a/R/excel_dates.R
+++ b/R/excel_dates.R
@@ -72,6 +72,9 @@ excel_numeric_to_date <- function(date_num, date_system = "modern", include_time
   mask_excel_leap_day_bug <- !is.na(date_num_days) & floor(date_num_days) == 60
   mask_before_excel_leap_day_bug <- !is.na(date_num_days) & floor(date_num_days) < 60
   date_num_days[mask_excel_leap_day_bug] <- NA_real_
+  if (any(date_num_days < 1)) {
+    warning("Only `date_num` >= 1 are valid in Excel, creating an earlier date than Excel supports.")
+  }
   date_num_days[mask_before_excel_leap_day_bug] <- date_num_days[mask_before_excel_leap_day_bug] + 1
   ret <-
     if (date_system == "mac pre-2011") {

--- a/tests/testthat/test-date-conversion.R
+++ b/tests/testthat/test-date-conversion.R
@@ -139,3 +139,14 @@ test_that("Nonexistent 29 Feb 1900 exists in Excel but not in accurate calendars
     as.Date(c("1900-02-28", NA, "1900-03-01"))
   )
 })
+
+test_that("Negative dates are invalid in Excel (issue #423)", {
+  expect_equal(
+    expect_warning(
+      excel_numeric_to_date(-1:1),
+      regexp="Only `date_num` >= 1 are valid in Excel, creating an earlier date than Excel supports.",
+      fixed=TRUE
+    ),
+    as.Date(c("1899-12-30", "1899-12-31", "1900-01-01"))
+  )
+})


### PR DESCRIPTION
Fix #423 

I did not make the warning a once-per-session warning as it likely indicates some form of data input issue that the user would want to fix.