### PR TITLE
sort tabyl by the integer as.numeric and not as.character

### DIFF
--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -55,8 +55,8 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
   } else {
     var_name <- names(dat)
   }
-
-
+  
+  
   # useful error message if input vector doesn't exist
   if (is.null(dat)) {
     stop(paste0("object ", var_name, " not found"))
@@ -65,7 +65,7 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
   if (length(var_name) > 1) {
     var_name <- paste(var_name, collapse = "")
   }
-
+  
   # if show_na is not length-1 logical, error helpfully (#377)
   if(length(show_na) > 1 || !inherits(show_na, "logical")){
     stop("The value supplied to the \"show_na\" argument must be TRUE or FALSE.\n\nDid you try to call tabyl on two vectors, like tabyl(data$var1, data$var2) ? To create a two-way tabyl, the two vectors must be in the same data.frame, and the function should be called like this: \n
@@ -84,7 +84,7 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
     dat_df <- data.frame(dat, stringsAsFactors = is.factor(dat))
     names(dat_df)[1] <- "dat"
     result <- dat_df %>% dplyr::count(dat)
-  
+    
     if (is.factor(dat) && show_missing_levels) {
       expanded <- tidyr::expand(result, dat)
       result <- merge( # can't use left_join b/c NA matching changed in 0.6.0
@@ -99,18 +99,18 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
   } else {
     stop("input must be a vector of type logical, numeric, character, list, or factor")
   }
-
+  
   # calculate percent, move NA row to bottom
   result <- result %>%
     dplyr::mutate(percent = n / sum(n, na.rm = TRUE))
-
+  
   # sort the NA row to the bottom, necessary to retain factor sorting
   result <- result[order(is.na(result$dat)), ]
   result$is_na <- NULL
-
+  
   # replace all NA values with 0 - only applies to missing factor levels
   result <- tidyr::replace_na(result, replace = list(n = 0, percent = 0))
-
+  
   ## NA handling:
   # if there are NA values & show_na = T, calculate valid % as a new column
   if (show_na && sum(is.na(result[[1]])) > 0) {
@@ -122,13 +122,13 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
       dplyr::filter(!is.na(.[1])) %>%
       dplyr::mutate(percent = n / sum(n, na.rm = TRUE)) # recalculate % without NAs
   }
-
+  
   # reassign correct variable name
   names(result)[1] <- var_name
-
+  
   # in case input var name was "n" or "percent", call helper function to set unique names
   result <- handle_if_special_names_used(result)
-
+  
   data.frame(result, check.names = FALSE) %>%
     as_tabyl(axes = 1)
 }
@@ -145,14 +145,14 @@ tabyl.data.frame <- function(dat, var1, var2, var3, show_na = TRUE, show_missing
   if (dplyr::is_grouped_df(dat)) {
     dat <- dplyr::ungroup(dat)
   }
-
+  
   if (missing(var2) && missing(var3) && !missing(var1)) {
     tabyl_1way(dat, rlang::enquo(var1), show_na = show_na, show_missing_levels = show_missing_levels)
   } else if (missing(var3) && !missing(var1) && !missing(var1)) {
     tabyl_2way(dat, rlang::enquo(var1), rlang::enquo(var2), show_na = show_na, show_missing_levels = show_missing_levels)
   } else if (!missing(var1) &&
-    !missing(var2) &&
-    !missing(var3)) {
+             !missing(var2) &&
+             !missing(var3)) {
     tabyl_3way(dat, rlang::enquo(var1), rlang::enquo(var2), rlang::enquo(var3), show_na = show_na, show_missing_levels = show_missing_levels)
   } else {
     stop("please specify var1 OR var1 & var2 OR var1 & var2 & var3")
@@ -162,14 +162,14 @@ tabyl.data.frame <- function(dat, var1, var2, var3, show_na = TRUE, show_missing
 # a one-way frequency table; this was called "tabyl" in janitor <= 0.3.0
 tabyl_1way <- function(dat, var1, show_na = TRUE, show_missing_levels = TRUE) {
   x <- dplyr::select(dat, !! var1)
-
+  
   # gather up arguments, pass them to tabyl.default
   arguments <- list()
   arguments$dat <- x[1]
   arguments$show_na <- show_na
   arguments$show_missing_levels <- show_missing_levels
   do.call(tabyl.default,
-    args = arguments
+          args = arguments
   )
 }
 
@@ -177,27 +177,30 @@ tabyl_1way <- function(dat, var1, show_na = TRUE, show_missing_levels = TRUE) {
 # a two-way frequency table; this was called "crosstab" in janitor <= 0.3.0
 tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TRUE) {
   dat <- dplyr::select(dat, !! var1, !! var2)
-
+  
   if (!show_na) {
     dat <- dat[!is.na(dat[[1]]) & !is.na(dat[[2]]), ]
   }
   if (nrow(dat) == 0) { # if passed a zero-length input, or an entirely NA input, return a zero-row data.frame
     message("No records to count so returning a zero-row tabyl")
     return(dat %>%
-      dplyr::select(1) %>%
-      dplyr::slice(0))
+             dplyr::select(1) %>%
+             dplyr::slice(0))
   }
-
-    tabl <- dat %>%
-      dplyr::count(!! var1, !! var2)
-
+  
+  tabl <- dat %>%
+    dplyr::count(!! var1, !! var2)
+  
   # Optionally expand missing factor levels.
   if (show_missing_levels) {
     tabl <- tidyr::complete(tabl, !! var1, !! var2)
   }
-
+  
   # replace NA with string NA_ in vec2 to avoid invalid col name after spreading
   # if this col is a factor, need to add that level to the factor
+  if (is.numeric(tabl[[2]])){
+    tabl[[2]] <- ordered(tabl[[2]], levels = unique(tabl[[2]]))
+  }
   if (is.factor(tabl[[2]])) {
     levels(tabl[[2]]) <- c(levels(tabl[[2]]), "emptystring_", "NA_")
   } else {
@@ -219,7 +222,7 @@ tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TR
     result <- result[c(setdiff(names(result), "NA_"), "NA_")]
   }
   
-
+  
   result %>%
     data.frame(., check.names = FALSE) %>%
     as_tabyl(axes = 2, row_var_name = names(dat)[1], col_var_name = names(dat)[2])
@@ -229,20 +232,23 @@ tabyl_2way <- function(dat, var1, var2, show_na = TRUE, show_missing_levels = TR
 # a list of two-way frequency tables, split into a list on a third variable
 tabyl_3way <- function(dat, var1, var2, var3, show_na = TRUE, show_missing_levels = TRUE) {
   dat <- dplyr::select(dat, !! var1, !! var2, !! var3)
+  if(is.numeric(dat[[3]])){
+    third_levels_for_sorting <- unique(ordered(dat[[3]], levels = unique(dat[[3]])))
+  }
   
   # Keep factor levels for ordering the list at the end
   if(is.factor(dat[[3]])){
     third_levels_for_sorting <- levels(dat[[3]])
   }
   dat[[3]] <- as.character(dat[[3]]) # don't want empty factor levels in the result list - they would be empty data.frames
-
+  
   # grab class of 1st variable to restore it later
   col1_class <- class(dat[[1]])
   col1_levels <- NULL
   if ("factor" %in% col1_class) {
     col1_levels <- levels(dat[[1]])
   }
-
+  
   # print NA level as its own data.frame, and make it appear last
   if (show_na && sum(is.na(dat[[3]])) > 0) {
     dat[[3]] <- factor(dat[[3]], levels = c(sort(unique(dat[[3]])), "NA_"))
@@ -251,20 +257,25 @@ tabyl_3way <- function(dat, var1, var2, var3, show_na = TRUE, show_missing_level
       third_levels_for_sorting <- c(third_levels_for_sorting, "NA_")
     }
   }
-
+  
   if (show_missing_levels) { # needed to have each crosstab in the list aware of all values in the pre-split variables
-   dat[[1]] <- as.factor(dat[[1]])
-   dat[[2]] <- as.factor(dat[[2]])
+    dat[[1]] <- as.factor(dat[[1]])
+    dat[[2]] <- as.factor(dat[[2]])
   }
-
+  
   result <- split(dat, dat[[rlang::quo_name(var3)]]) %>%
     purrr::map(tabyl_2way, var1, var2, show_na = show_na, show_missing_levels = show_missing_levels) %>%
     purrr::map(reset_1st_col_status, col1_class, col1_levels) # reset class of var in 1st col to its input class, #168
-
+  
   # reorder when var 3 is a factor, per #250
   if(exists("third_levels_for_sorting")){
     result <- result[order(third_levels_for_sorting[third_levels_for_sorting %in% unique(dat[[3]])])] 
   }
+  
+  if(all(!is.na(as.numeric(as.character(dat[[3]]))))){
+    result <- result[order(as.numeric(names(result)))]
+  }
+  
   
   result
 }

--- a/tests/testthat/test-tabyl.R
+++ b/tests/testthat/test-tabyl.R
@@ -466,3 +466,19 @@ test_that("tabyl errors informatively called like tabyl(mtcars$cyl, mtcars$gear)
     "list"
   )
 })
+
+test_that("2-way tabyl with numeric column names is sorted numerically", {
+  
+  df <- data.frame(var1 = c(1:10), var2 = c(1:10))
+  
+  expect_equal(colnames(df %>% tabyl(var1,var2)), c("var1", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"))
+})
+
+test_that("3-way tabyl with numeric names is sorted numerically", {
+  
+  expect_equal(names(mtcars %>% tabyl(gear,cyl,hp)), 
+               c("52", "62", "65", "66", "91", "93", "95", "97", "105", "109", 
+                 "110", "113", "123", "150", "175", "180", "205", "215", "230", 
+                 "245", "264", "335"))
+  
+})


### PR DESCRIPTION
## Description
Fixes 2-way and 3-way tabyl ordering when column names are numeric.

## Related Issue
Fixes #438 - tried to follow most of the advice with a few tweaks to get things (hopefully) working correctly.

## Example

2-way tabyl:

```
df <- data.frame(var1 = c(1:10),var2 = c(1:10))

df %>% tabyl(var1,var2)
```
Now outputs:

```
> df %>% tabyl(var1,var2)
 var1 1 2 3 4 5 6 7 8 9 10
    1 1 0 0 0 0 0 0 0 0  0
    2 0 1 0 0 0 0 0 0 0  0
    3 0 0 1 0 0 0 0 0 0  0
    4 0 0 0 1 0 0 0 0 0  0
    5 0 0 0 0 1 0 0 0 0  0
    6 0 0 0 0 0 1 0 0 0  0
    7 0 0 0 0 0 0 1 0 0  0
    8 0 0 0 0 0 0 0 1 0  0
    9 0 0 0 0 0 0 0 0 1  0
   10 0 0 0 0 0 0 0 0 0  1
```
3-way tabyl:

```
names(
  data.frame(var1 = 1:10, var2 = 1:10, var3 = 1:10) %>%
    mutate(var2 = ordered(var2, levels = var2)) %>%
    tabyl(var1, var2, var3)
)
```
Now outputs:

```
 [1] "1"  "2"  "3"  "4"  "5"  "6"  "7"  "8"  "9"  "10"
```


Added two tests as well - I'm sure this could be more comprehensive but I'm pretty new to R package development.

Thanks so much for your work on janitor, and congrats on 1 million downloads! 
