### PR TITLE
fix for dplyr 1.0.8

### DIFF
--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -119,7 +119,7 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
     result$valid_percent[is.na(result[[1]])] <- NA
   } else { # don't show NA values, which necessitates adjusting the %s
     result <- result %>%
-      dplyr::filter(!is.na(.[1])) %>%
+      dplyr::filter(!is.na(.[,1])) %>%
       dplyr::mutate(percent = n / sum(n, na.rm = TRUE)) # recalculate % without NAs
   }
   


### PR DESCRIPTION
We're about to release dplyr 1.0.8, and identified a problem with `janitor` when doing our revdep checks. 

This is because `filter()` no longer deals with matrices, but from what I understand this pull request fixes the problem. I assume you meant to call `is.na()` on the first column, rather than calling `is.na()` on a data frame with one column, which gives a matrix. 

This pull request should be fine with both the cran and future version of `dplyr`. Please consider releasing `janitor`. 