### PR TITLE
Fix typo in `convert_to_date` docs, remove explicit reference to non-exported functions

### DIFF
--- a/R/convert_to_date.R
+++ b/R/convert_to_date.R
@@ -11,7 +11,7 @@
 #' @param tz The timezone for POSIXct output, unless an object is POSIXt
 #'   already.  Ignored for Date output.
 #' @param ... Passed to further methods.  Eventually may be passed to
-#'   `excel_numeric_to_date()`, `base::as.POXIXct()`, or `base::as.Date()`.
+#'   `excel_numeric_to_date()`, `base::as.POSIXct()`, or `base::as.Date()`.
 #' @param character_fun A function to convert non-numeric-looking, non-NA values
 #'   in `x` to POSIXct objects.
 #' @param string_conversion_failure If a character value fails to parse into the

--- a/R/make_clean_names.R
+++ b/R/make_clean_names.R
@@ -181,7 +181,7 @@ make_clean_names <- function(string,
 #' @keywords Internal
 #' @noRd
 warn_micro_mu <- function(string, replace) {
-  micro_mu <- names(janitor:::mu_to_u)
+  micro_mu <- names(mu_to_u)
   # The vector of characters that exist but are not handled at all
   warning_characters <- character()
   # The vector of characters that exist and may be handled by a specific replacement

--- a/R/tabyl.R
+++ b/R/tabyl.R
@@ -39,7 +39,7 @@
 tabyl <- function(dat, ...) UseMethod("tabyl")
 
 
-#' @inheritParams tabyl
+
 #' @export
 #' @rdname tabyl
 # this method runs when tabyl() is called on plain vectors; tabyl_1way
@@ -134,7 +134,7 @@ tabyl.default <- function(dat, show_na = TRUE, show_missing_levels = TRUE, ...) 
 }
 
 
-#' @inheritParams tabyl
+
 #' @export
 #' @rdname tabyl
 # Main dispatching function to underlying functions depending on whether "..." contains 1, 2, or 3 variables

--- a/man/convert_to_date.Rd
+++ b/man/convert_to_date.Rd
@@ -25,7 +25,7 @@ convert_to_datetime(
 \item{x}{The object to convert}
 
 \item{...}{Passed to further methods.  Eventually may be passed to
-`excel_numeric_to_date()`, `base::as.POXIXct()`, or `base::as.Date()`.}
+`excel_numeric_to_date()`, `base::as.POSIXct()`, or `base::as.Date()`.}
 
 \item{character_fun}{A function to convert non-numeric-looking, non-NA values
 in `x` to POSIXct objects.}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Hi,

Awesome package, this PR aims to fix typos in the documentation of `convert_to_date` and also removes the usage of `:::` to refer to `mu_to_u` since this is already defined elsewhere in the package. 

I also removed a redundant `@inheritParams` from `tybl`.
## Related Issue

#472 

Thank you,
NelsonGon 
