### PR TITLE
clean_names() support for all types

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,6 @@
 
 S3method(chisq.test,default)
 S3method(chisq.test,tabyl)
-S3method(clean_names,data.frame)
 S3method(clean_names,default)
 S3method(clean_names,sf)
 S3method(clean_names,tbl_graph)

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@
 
 * `make_clean_names()` (and therefore `clean_names()`) issues a warning if the mu or micro symbol is in the names and it is not or may not be handled by a `replace` argument value.  (#448, thanks **@IndrajeetPatil** for reporting and **@billdenney** for fixing)  The rationale is that standard transliteration would convert "[mu]g" to "mg" when it would be more typically be converted to "ug" for use as a unit.  A new, unexported constant (janitor:::mu_to_u) was added to help with mu to "u" replacements.
 
+* `clean_names()` now supports all object types that have either names or dimnames (#481, @DanChaltiel).
+
 ## Bug fixes
 
 * When a numeric variable is supplied as the 2nd variable (column) or 3rd variable (list) of a `tabyl`, the resulting columns or list are now sorted in numeric order, not alphabetic. (#438, thanks **@daaronr** for reporting and **@mattroumaya** for fixing)

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -79,8 +79,7 @@ clean_names.default <- function(dat, ...) {
     return(dat)
   }
   if(is.null(names(dat))) {
-    colnames(dat) <- make_clean_names(colnames(dat), ...)
-    rownames(dat) <- make_clean_names(rownames(dat), ...)
+    dimnames(dat) <- lapply(dimnames(dat), make_clean_names, ...)
   } else {
     names(dat) <- make_clean_names(names(dat), ...)
   }

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -76,7 +76,6 @@ clean_names.default <- function(dat, ...) {
       "`clean_names()` requires that either names or dimnames be non-null.",
       call. = FALSE
     )
-    return(dat)
   }
   if(is.null(names(dat))) {
     dimnames(dat) <- lapply(dimnames(dat), make_clean_names, ...)

--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -70,17 +70,21 @@ clean_names <- function(dat, ...) {
 
 #' @rdname clean_names
 #' @export
-clean_names.data.frame <- function(dat, ...) {
-  stats::setNames(dat, make_clean_names(names(dat), ...))
-}
-
-#' @rdname clean_names
-#' @export
 clean_names.default <- function(dat, ...) {
-  stop(
-    "No `clean_names()` method exists for the class ", paste(class(dat), collapse=", "),
-    "\nConsider janitor::make_clean_names() for other cases of manipulating vectors of names."
-  )
+  if(is.null(names(dat)) && is.null(dimnames(dat))) {
+    stop(
+      "`clean_names()` requires that either names or dimnames be non-null.",
+      call. = FALSE
+    )
+    return(dat)
+  }
+  if(is.null(names(dat))) {
+    colnames(dat) <- make_clean_names(colnames(dat), ...)
+    rownames(dat) <- make_clean_names(rownames(dat), ...)
+  } else {
+    names(dat) <- make_clean_names(names(dat), ...)
+  }
+  dat
 }
 
 #' @rdname clean_names

--- a/man/clean_names.Rd
+++ b/man/clean_names.Rd
@@ -2,15 +2,12 @@
 % Please edit documentation in R/clean_names.R
 \name{clean_names}
 \alias{clean_names}
-\alias{clean_names.data.frame}
 \alias{clean_names.default}
 \alias{clean_names.sf}
 \alias{clean_names.tbl_graph}
 \title{Cleans names of an object (usually a data.frame).}
 \usage{
 clean_names(dat, ...)
-
-\method{clean_names}{data.frame}(dat, ...)
 
 \method{clean_names}{default}(dat, ...)
 

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -392,6 +392,15 @@ test_that("Tests for clean_names.default() on lists and vectors", {
   )
 })
 
+test_that("Tests for clean_names.default() on arrays", {
+  x = array(NA, dim = c(2, 2, 2), dimnames = list(c("A", "B"), c("C", "D"), c("E", "F")))
+  clean = clean_names(x)
+  test = unlist(dimnames(x))
+  expect_false(isTRUE(all.equal(test, tolower(test))))
+  test_clean = unlist(dimnames(clean))
+  expect_true(isTRUE(all.equal(test_clean, tolower(test_clean))))
+})
+
 
 #------------------------------------------------------------------------------# 
 #---------------------------- Tests for sf method -----------------------------####

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -377,8 +377,8 @@ test_that("Tests for clean_names.default() on lists and vectors", {
   test_list <- as.list(test_v)
   
   # Warnings due to partially handled mu
-  clean_v <- suppressWarnings(clean_names(test_v))
-  clean_l <- suppressWarnings(clean_names(test_list))
+  clean_v <- expect_warning(clean_names(test_v), regexp="mu or micro symbol")
+  clean_l <- expect_warning(clean_names(test_list), regexp="mu or micro symbol")
   expect_equal(names(clean_v)[1], "sp_ace")
   expect_equal(names(clean_l)[1], "sp_ace")
   expect_type(clean_v, "integer")

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -371,10 +371,23 @@ test_that("Tests for cases beyond default snake", {
   expect_warning(expect_equal(names(clean_names(test_df, "small_camel")), names(clean_names(test_df, "lower_camel"))))
 })
 
-test_that("errors if not called on a data.frame", {
+test_that("Tests for clean_names.default() on lists and vectors", {
+  test_v <- seq_along(testing_vector)
+  names(test_v) <- testing_vector
+  test_list <- as.list(test_v)
+  
+  # Warnings due to partially handled mu
+  clean_v <- suppressWarnings(clean_names(test_v))
+  clean_l <- suppressWarnings(clean_names(test_list))
+  expect_equal(names(clean_v)[1], "sp_ace")
+  expect_equal(names(clean_l)[1], "sp_ace")
+  expect_type(clean_v, "integer")
+  expect_type(clean_l, "list")
+  
+  unnamed <- seq_along(testing_vector)
   expect_error(
-    clean_names(1:3),
-    regexp="No `clean_names()` method exists for the class integer",
+    clean_names(unnamed),
+    regexp="requires that either names or dimnames be non-null.",
     fixed=TRUE
   )
 })


### PR DESCRIPTION
## Description
Enhance `clean_names.default()` to support all types of objects as long as they have either names or dimnames.

## Related Issue
fixes #481 

## Example
``` r
x = c("A%"=1, 2, 3)
names(x)
#> [1] "A%" ""   ""
janitor::clean_names(x)
#> a_percent         x       x_2 
#>         1         2         3

x = matrix(NA, nrow=2, ncol=2, dimnames=list(c("A B", "B C"), c("C D", "D E")))
janitor::clean_names(x)
#>     c_d d_e
#> a_b  NA  NA
#> b_c  NA  NA

x = 1:10
janitor::clean_names(x)
#> Error: `clean_names()` requires that either names or dimnames be non-null.
```

<sup>Created on 2022-05-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

