### PR TITLE
Adds `allow_dupes`, fixes #495

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * A minor breaking change is that the time zone is now always set for `excel_numeric_to_date()` and `convert_date()`.  The default timezone is `Sys.timezone()`, previously it was an empty string (`""`). (#422, thanks **@billdenney** for fixing)
 
-* A minor breaking change effects `make_clean_names()` (and therefore `clean_names()`). `make_clean_names()` now uses the `unique_sep` argument from `snakecase::make_any_case()` to handle de-duplication of names. The incremental suffix counter is now one less than in the past (i.e., a de-duplicated variable with a suffix of `_2` becomes `_1`, `_3` becomes `_2`, etc.). This change also results in a new feature and the ability to allow for duplicate names by setting `unique_sep = NULL`. (#495, thanks **@JasonAizkalns** for fixing and **@billdenney** and **@sfrike** for the guidance)
+* A minor breaking change affects `make_clean_names()` (and therefore `clean_names()`). `make_clean_names()` now uses the `unique_sep` argument from `snakecase::to_any_case()` to handle de-duplication of names. The incremental suffix counter is now one less than in the past (i.e., a de-duplicated variable with a suffix of `_2` becomes `_1`, `_3` becomes `_2`, etc.). This change also results in a new feature and the ability to allow for duplicate names by setting `unique_sep = NULL`. (#495, thanks **@JasonAizkalns** for fixing and **@billdenney** and **@sfrike** for the guidance)
 
 ## New features
 
@@ -29,8 +29,7 @@
 
 * `clean_names()` now supports all object types that have either names or dimnames (#481, @DanChaltiel).
 
-* `make_clean_names()` now allows duplicate names to be returned with the `allow_dupes = TRUE`
-argument (#495, @JasonAizkalns).
+* `make_clean_names()` allows duplicate names to be returned by specifying `unique_sep = NULL` (#495, @JasonAizkalns).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * A minor breaking change is that the time zone is now always set for `excel_numeric_to_date()` and `convert_date()`.  The default timezone is `Sys.timezone()`, previously it was an empty string (`""`). (#422, thanks **@billdenney** for fixing)
 
+* A minor breaking change effects `make_clean_names()` (and therefore `clean_names()`). `make_clean_names()` now uses the `unique_sep` argument from `snakecase::make_any_case()` to handle de-duplication of names. The incremental suffix counter is now one less than in the past (i.e., a de-duplicated variable with a suffix of `_2` becomes `_1`, `_3` becomes `_2`, etc.). This change also results in a new feature and the ability to allow for duplicate names by setting `unique_sep = NULL`. (#495, thanks **@JasonAizkalns** for fixing and **@billdenney** and **@sfrike** for the guidance)
+
 ## New features
 
 * `row_to_names()` now has a new helper function, `find_header()` to help find the row that contains the names.  It can be used by passing `row_number="find_header"`, and see the documentation of `row_to_names()` and `find_header()` for more examples. (fix #429)

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,9 @@
 
 * `clean_names()` now supports all object types that have either names or dimnames (#481, @DanChaltiel).
 
+* `make_clean_names()` now allows duplicate names to be returned with the `allow_dupes = TRUE`
+argument (#495, @JasonAizkalns).
+
 ## Bug fixes
 
 * `adorn_percentages()` was refactored for compatibility with `dplyr` package versions > 1.0.99 (#490)

--- a/R/make_clean_names.R
+++ b/R/make_clean_names.R
@@ -49,8 +49,9 @@
 #' @param use_make_names Should \code{make.names()} be applied to ensure that the
 #'   output is usable as a name without quoting?  (Avoiding \code{make.names()}
 #'   ensures that the output is locale-independent but quoting may be required.)
-#' @param allow_dupes Allow duplicates \code{TRUE} in the returned names or
-#'   not (\code{FALSE}, default).
+#' @param unique_sep When provided a character (\code{"_"}, default), an incremental
+#'   counter is appended to repeated instances of duplicate variable names. If 
+#'   duplicate names are desired, use \code{unique_sep = NULL}.
 #' @inheritParams snakecase::to_any_case
 #' @inheritDotParams snakecase::to_any_case
 #'
@@ -86,7 +87,7 @@ make_clean_names <- function(string,
                                ),
                              ascii=TRUE,
                              use_make_names=TRUE,
-                             allow_dupes=FALSE,
+                             unique_sep="_",
                              # default arguments for snake_case::to_any_case
                              sep_in = "\\.",
                              transliterations = "Latin-ASCII",
@@ -152,30 +153,10 @@ make_clean_names <- function(string,
       transliterations = transliterations,
       parsing_option = parsing_option,
       numerals = numerals,
+      unique_sep = unique_sep,
       ...
     )
   
-  # Handle duplicated names - they mess up dplyr pipelines. This appends an
-  # incremental counter to repeated instances of duplicate variable names.
-  if (!allow_dupes) {
-    while (any(duplicated(cased_names))) {
-      dupe_count <-
-        vapply(
-          seq_along(cased_names), function(i) {
-            sum(cased_names[i] == cased_names[1:i])
-          },
-          1L
-        )
-      
-      cased_names[dupe_count > 1] <-
-        paste(
-          cased_names[dupe_count > 1],
-          dupe_count[dupe_count > 1],
-          sep = "_"
-        )
-    }    
-  }
-
   cased_names
 }
 

--- a/R/make_clean_names.R
+++ b/R/make_clean_names.R
@@ -49,6 +49,8 @@
 #' @param use_make_names Should \code{make.names()} be applied to ensure that the
 #'   output is usable as a name without quoting?  (Avoiding \code{make.names()}
 #'   ensures that the output is locale-independent but quoting may be required.)
+#' @param allow_dupes Allow duplicates \code{TRUE} in the returned names or
+#'   not (\code{FALSE}, default).
 #' @inheritParams snakecase::to_any_case
 #' @inheritDotParams snakecase::to_any_case
 #'
@@ -84,6 +86,7 @@ make_clean_names <- function(string,
                                ),
                              ascii=TRUE,
                              use_make_names=TRUE,
+                             allow_dupes=FALSE,
                              # default arguments for snake_case::to_any_case
                              sep_in = "\\.",
                              transliterations = "Latin-ASCII",
@@ -152,24 +155,27 @@ make_clean_names <- function(string,
       ...
     )
   
-  # Handle duplicated names - they mess up dplyr pipelines.  This appends the
-  # column number to repeated instances of duplicate variable names.
-  while (any(duplicated(cased_names))) {
-    dupe_count <-
-      vapply(
-        seq_along(cased_names), function(i) {
-          sum(cased_names[i] == cased_names[1:i])
-        },
-        1L
-      )
-  
-    cased_names[dupe_count > 1] <-
-      paste(
-        cased_names[dupe_count > 1],
-        dupe_count[dupe_count > 1],
-        sep = "_"
-      )
+  # Handle duplicated names - they mess up dplyr pipelines. This appends an
+  # incremental counter to repeated instances of duplicate variable names.
+  if (!allow_dupes) {
+    while (any(duplicated(cased_names))) {
+      dupe_count <-
+        vapply(
+          seq_along(cased_names), function(i) {
+            sum(cased_names[i] == cased_names[1:i])
+          },
+          1L
+        )
+      
+      cased_names[dupe_count > 1] <-
+        paste(
+          cased_names[dupe_count > 1],
+          dupe_count[dupe_count > 1],
+          sep = "_"
+        )
+    }    
   }
+
   cased_names
 }
 

--- a/man/clean_names.Rd
+++ b/man/clean_names.Rd
@@ -35,6 +35,8 @@ value.}
     \item{\code{use_make_names}}{Should \code{make.names()} be applied to ensure that the
 output is usable as a name without quoting?  (Avoiding \code{make.names()}
 ensures that the output is locale-independent but quoting may be required.)}
+    \item{\code{allow_dupes}}{Allow duplicates \code{TRUE} in the returned names or
+not (\code{FALSE}, default).}
     \item{\code{sep_in}}{(short for separator input) if character, is interpreted as a
 regular expression (wrapped internally into \code{stringr::regex()}). 
 The default value is a regular expression that matches any sequence of
@@ -42,14 +44,6 @@ non-alphanumeric values. All matches will be replaced by underscores
 (additionally to \code{"_"} and \code{" "}, for which this is always true, even
 if \code{NULL} is supplied). These underscores are used internally to split
 the strings into substrings and specify the word boundaries.}
-    \item{\code{transliterations}}{A character vector (if not \code{NULL}). The entries of this argument
-need to be elements of \code{stringi::stri_trans_list()} (like "Latin-ASCII", which is often useful) or names of lookup tables (currently only "german" is supported). In the order of the entries the letters of the input
- string will be transliterated via \code{stringi::stri_trans_general()} or replaced via the 
- matches of the lookup table. When named character elements are supplied as part of `transliterations`, anything that matches the names is replaced by the corresponding value.
-You should use this feature with care in case of \code{case = "parsed"}, \code{case = "internal_parsing"} and 
-\code{case = "none"}, since for upper case letters, which have transliterations/replacements
- of length 2, the second letter will be transliterated to lowercase, for example Oe, Ae, Ss, which
- might not always be what is intended. In this case you can make usage of the option to supply named elements and specify the transliterations yourself.}
     \item{\code{parsing_option}}{An integer that will determine the parsing_option.
 \itemize{
  \item{1: \code{"RRRStudio" -> "RRR_Studio"}}
@@ -58,6 +52,14 @@ You should use this feature with care in case of \code{case = "parsed"}, \code{c
  \item{-1, -2, -3: These \code{parsing_options}'s will suppress the conversion after non-alphanumeric values.}
  \item{0: no parsing}
  }}
+    \item{\code{transliterations}}{A character vector (if not \code{NULL}). The entries of this argument
+need to be elements of \code{stringi::stri_trans_list()} (like "Latin-ASCII", which is often useful) or names of lookup tables (currently only "german" is supported). In the order of the entries the letters of the input
+ string will be transliterated via \code{stringi::stri_trans_general()} or replaced via the 
+ matches of the lookup table. When named character elements are supplied as part of `transliterations`, anything that matches the names is replaced by the corresponding value.
+You should use this feature with care in case of \code{case = "parsed"}, \code{case = "internal_parsing"} and 
+\code{case = "none"}, since for upper case letters, which have transliterations/replacements
+ of length 2, the second letter will be transliterated to lowercase, for example Oe, Ae, Ss, which
+ might not always be what is intended. In this case you can make usage of the option to supply named elements and specify the transliterations yourself.}
     \item{\code{numerals}}{A character specifying the alignment of numerals (\code{"middle"}, \code{left}, \code{right}, \code{asis} or \code{tight}). I.e. \code{numerals = "left"} ensures that no output separator is in front of a digit.}
   }}
 }

--- a/man/clean_names.Rd
+++ b/man/clean_names.Rd
@@ -35,8 +35,9 @@ value.}
     \item{\code{use_make_names}}{Should \code{make.names()} be applied to ensure that the
 output is usable as a name without quoting?  (Avoiding \code{make.names()}
 ensures that the output is locale-independent but quoting may be required.)}
-    \item{\code{allow_dupes}}{Allow duplicates \code{TRUE} in the returned names or
-not (\code{FALSE}, default).}
+    \item{\code{unique_sep}}{When provided a character (\code{"_"}, default), an incremental
+counter is appended to repeated instances of duplicate variable names. If 
+duplicate names are desired, use \code{unique_sep = NULL}.}
     \item{\code{sep_in}}{(short for separator input) if character, is interpreted as a
 regular expression (wrapped internally into \code{stringr::regex()}). 
 The default value is a regular expression that matches any sequence of

--- a/man/make_clean_names.Rd
+++ b/man/make_clean_names.Rd
@@ -10,7 +10,7 @@ make_clean_names(
   replace = c(`'` = "", `"` = "", `\%` = "_percent_", `#` = "_number_"),
   ascii = TRUE,
   use_make_names = TRUE,
-  allow_dupes = FALSE,
+  unique_sep = "_",
   sep_in = "\\\\.",
   transliterations = "Latin-ASCII",
   parsing_option = 1,
@@ -39,8 +39,9 @@ value.}
 output is usable as a name without quoting?  (Avoiding \code{make.names()}
 ensures that the output is locale-independent but quoting may be required.)}
 
-\item{allow_dupes}{Allow duplicates \code{TRUE} in the returned names or
-not (\code{FALSE}, default).}
+\item{unique_sep}{When provided a character (\code{"_"}, default), an incremental
+counter is appended to repeated instances of duplicate variable names. If 
+duplicate names are desired, use \code{unique_sep = NULL}.}
 
 \item{sep_in}{(short for separator input) if character, is interpreted as a
 regular expression (wrapped internally into \code{stringr::regex()}). 
@@ -78,10 +79,6 @@ You should use this feature with care in case of \code{case = "parsed"}, \code{c
 Use this feature with care: One letter abbreviations and abbreviations next to each other are hard to read and also not easy to parse for further processing.}
     \item{\code{sep_out}}{(short for separator output) String that will be used as separator. The defaults are \code{"_"} 
 and \code{""}, regarding the specified \code{case}. When \code{length(sep_out) > 1}, the last element of \code{sep_out} gets recycled and separators are incorporated per string according to their order.}
-    \item{\code{unique_sep}}{A string. If not \code{NULL}, then duplicated names will get 
-a suffix integer
-in the order of their appearance. The suffix is separated by the supplied string
- to this argument.}
     \item{\code{empty_fill}}{A string. If it is supplied, then each entry that matches "" will be replaced
 by the supplied string to this argument.}
     \item{\code{prefix}}{prefix (string).}

--- a/man/make_clean_names.Rd
+++ b/man/make_clean_names.Rd
@@ -10,6 +10,7 @@ make_clean_names(
   replace = c(`'` = "", `"` = "", `\%` = "_percent_", `#` = "_number_"),
   ascii = TRUE,
   use_make_names = TRUE,
+  allow_dupes = FALSE,
   sep_in = "\\\\.",
   transliterations = "Latin-ASCII",
   parsing_option = 1,
@@ -37,6 +38,9 @@ value.}
 \item{use_make_names}{Should \code{make.names()} be applied to ensure that the
 output is usable as a name without quoting?  (Avoiding \code{make.names()}
 ensures that the output is locale-independent but quoting may be required.)}
+
+\item{allow_dupes}{Allow duplicates \code{TRUE} in the returned names or
+not (\code{FALSE}, default).}
 
 \item{sep_in}{(short for separator input) if character, is interpreted as a
 regular expression (wrapped internally into \code{stringr::regex()}). 

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -188,6 +188,13 @@ test_that("do not create duplicates (fix #251)", {
   )
 })
 
+test_that("do not create duplicates; force collision (fix #251)", {
+  expect_equal(
+    make_clean_names(c("a", "a", "a_1")),
+    c("a", "a_2", "a_1")
+  )
+})
+
 test_that("allow duplicates with unique_sep = NULL (fix #495)", {
   expect_equal(
     make_clean_names(c("a", "a 2", "a 2", "a_2"), unique_sep = NULL),

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -23,7 +23,7 @@ test_that("All scenarios for make_clean_names", {
   )
   expect_equal(
     make_clean_names(c("repeated", "repeated", "REPEATED")),
-    paste0("repeated", c("", "_2", "_3"))
+    paste0("repeated", c("", "_1", "_2"))
   )
   expect_equal(
     make_clean_names("a**^@"),
@@ -48,7 +48,7 @@ test_that("All scenarios for make_clean_names", {
   )
   expect_equal(
     make_clean_names(c("*", "!")),
-    c("x", "x_2")
+    c("x", "x_1")
   )
   expect_equal(
     make_clean_names("d(!)9"),
@@ -184,14 +184,21 @@ test_that("locale-specific make_clean_names tests", {
 test_that("do not create duplicates (fix #251)", {
   expect_equal(
     make_clean_names(c("a", "a", "a_2")),
-    c("a", "a_2", "a_2_2")
+    c("a", "a_1", "a_2")
   )
 })
 
-test_that("allow for duplicates (fix #495)", {
+test_that("allow duplicates with unique_sep = NULL (fix #495)", {
   expect_equal(
-    make_clean_names(c("a", "a", "a_2"), allow_dupes = TRUE),
-    c("a", "a", "a_2")
+    make_clean_names(c("a", "a 2", "a 2", "a_2"), unique_sep = NULL),
+    c("a", "a_2", "a_2", "a_2")
+  )
+})
+
+test_that("unique_sep with non-default argument does not create duplicates", {
+  expect_equal(
+    make_clean_names(c("a", "a 2", "a 2", "a_2"), unique_sep = ""),
+    c("a", "a_2", "a_21", "a_22")
   )
 })
 
@@ -303,19 +310,19 @@ test_that("Tests for cases beyond default snake", {
   expect_warning(expect_equal(
     names(clean_names(test_df, "small_camel")),
     c(
-      "spAce", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2",
-      "cant", "hiThere", "leadingSpaces", "x_3", "acao", "faroe", "aBCDEF",
+      "spAce", "repeated", "a", "percent", "x", "x_1", "d9", "repeated_1",
+      "cant", "hiThere", "leadingSpaces", "x_2", "acao", "faroe", "aBCDEF",
       "testCamelCase", "leadingpunct", "averageNumberOfDays",
-      "jan2009Sales", "jan2009Sales_2", "notFirstUnicodeM", "mFirstUnicode"
+      "jan2009Sales", "jan2009Sales_1", "notFirstUnicodeM", "mFirstUnicode"
     )
   ))
   # warning due to unhandled mu
   expect_warning(expect_equal(
     names(clean_names(test_df, "big_camel")),
     c(
-      "SpAce", "Repeated", "A", "Percent", "X", "X_2", "D9", "Repeated_2",
-      "Cant", "HiThere", "LeadingSpaces", "X_3", "Acao", "Faroe", "ABCDEF", "TestCamelCase",
-      "Leadingpunct", "AverageNumberOfDays", "Jan2009Sales", "Jan2009Sales_2",
+      "SpAce", "Repeated", "A", "Percent", "X", "X_1", "D9", "Repeated_1",
+      "Cant", "HiThere", "LeadingSpaces", "X_2", "Acao", "Faroe", "ABCDEF", "TestCamelCase",
+      "Leadingpunct", "AverageNumberOfDays", "Jan2009Sales", "Jan2009Sales_1",
       "NotFirstUnicodeM", "MFirstUnicode"
     )
   ))
@@ -323,8 +330,8 @@ test_that("Tests for cases beyond default snake", {
   expect_warning(expect_equal(
     names(clean_names(test_df, "all_caps")),
     c(
-      "SP_ACE", "REPEATED", "A", "PERCENT", "X", "X_2", "D_9", "REPEATED_2",
-      "CANT", "HI_THERE", "LEADING_SPACES", "X_3", "ACAO", "FAROE", "A_B_C_D_E_F",
+      "SP_ACE", "REPEATED", "A", "PERCENT", "X", "X_1", "D_9", "REPEATED_1",
+      "CANT", "HI_THERE", "LEADING_SPACES", "X_2", "ACAO", "FAROE", "A_B_C_D_E_F",
       "TEST_CAMEL_CASE", "LEADINGPUNCT", "AVERAGE_NUMBER_OF_DAYS", "JAN2009SALES",
       "JAN_2009_SALES",
       "NOT_FIRST_UNICODE_M", "M_FIRST_UNICODE"
@@ -334,28 +341,28 @@ test_that("Tests for cases beyond default snake", {
   expect_warning(expect_equal(
     names(clean_names(test_df, "lower_upper")),
     c(
-      "spACE", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2",
-      "cant", "hiTHERE", "leadingSPACES", "x_3", "acao", "faroe", "aBcDeF",
+      "spACE", "repeated", "a", "percent", "x", "x_1", "d9", "repeated_1",
+      "cant", "hiTHERE", "leadingSPACES", "x_2", "acao", "faroe", "aBcDeF",
       "testCAMELcase", "leadingpunct", "averageNUMBERofDAYS", "jan2009SALES",
-      "jan2009SALES_2", "notFIRSTunicodeM", "mFIRSTunicode"
+      "jan2009SALES_1", "notFIRSTunicodeM", "mFIRSTunicode"
     )
   ))
   # warning due to unhandled mu
   expect_warning(expect_equal(
     names(clean_names(test_df, "upper_lower")),
     c(
-      "SPace", "REPEATED", "A", "PERCENT", "X", "X_2", "D9", "REPEATED_2",
-      "CANT", "HIthere", "LEADINGspaces", "X_3", "ACAO", "FAROE", "AbCdEf",
+      "SPace", "REPEATED", "A", "PERCENT", "X", "X_1", "D9", "REPEATED_1",
+      "CANT", "HIthere", "LEADINGspaces", "X_2", "ACAO", "FAROE", "AbCdEf",
       "TESTcamelCASE", "LEADINGPUNCT", "AVERAGEnumberOFdays", "JAN2009sales",
-      "JAN2009sales_2", "NOTfirstUNICODEm", "MfirstUNICODE"
+      "JAN2009sales_1", "NOTfirstUNICODEm", "MfirstUNICODE"
     )
   ))
   # warning due to unhandled mu
   expect_warning(expect_equal(
     names(clean_names(test_df, "none")),
     c(
-      "sp_ace", "repeated", "a", "percent", "X", "X_2", "d_9", "REPEATED",
-      "cant", "hi_there", "leading_spaces", "X_3", "acao", "Faroe", "a_b_c_d_e_f", 
+      "sp_ace", "repeated", "a", "percent", "X", "X_1", "d_9", "REPEATED",
+      "cant", "hi_there", "leading_spaces", "X_2", "acao", "Faroe", "a_b_c_d_e_f", 
       "testCamelCase", "leadingpunct", "average_number_of_days", 
       "jan2009sales", "jan_2009_sales", "not_first_unicode_m", "m_first_unicode"
     )
@@ -449,13 +456,13 @@ test_that("Names are cleaned appropriately", {
   expect_equal(names(clean)[3], "a") # multiple special chars, trailing special chars
   expect_equal(names(clean)[4], "percent") # converting % to percent
   expect_equal(names(clean)[5], "x") # 100% invalid name
-  expect_equal(names(clean)[6], "x_2") # repeat of invalid name
+  expect_equal(names(clean)[6], "x_1") # repeat of invalid name
   expect_equal(names(clean)[7], "d_9") # multiple special characters
-  expect_equal(names(clean)[8], "repeated_2") # uppercase, 2nd instance of repeat
+  expect_equal(names(clean)[8], "repeated_1") # uppercase, 2nd instance of repeat
   expect_equal(names(clean)[9], "cant") # uppercase, 2nd instance of repeat
   expect_equal(names(clean)[10], "hi_there") # double-underscores to single
   expect_equal(names(clean)[11], "leading_spaces") # leading spaces
-  expect_equal(names(clean)[12], "x_3") # euro sign, invalid
+  expect_equal(names(clean)[12], "x_2") # euro sign, invalid
   expect_equal(names(clean)[13], "acao") # accented word, transliterated to latin,
   expect_equal(names(clean)[14], "faroe") # œ character was failing to convert on Windows, should work universally for stringi 1.1.6 or higher
   # https://github.com/sfirke/janitor/issues/120#issuecomment-303385418
@@ -488,43 +495,43 @@ test_that("Tests for cases beyond default snake for sf objects", {
   expect_equal(
     names(clean_names(test_df, "small_camel")),
     c(
-      "spAce", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2",
-      "cant", "hiThere", "leadingSpaces", "x_3", "acao", "faroe", "aBCDEF", "testCamelCase", "leadingpunct", "averageNumberOfDays", "jan2009Sales", "jan2009Sales_2", "geometry"
+      "spAce", "repeated", "a", "percent", "x", "x_1", "d9", "repeated_1",
+      "cant", "hiThere", "leadingSpaces", "x_2", "acao", "faroe", "aBCDEF", "testCamelCase", "leadingpunct", "averageNumberOfDays", "jan2009Sales", "jan2009Sales_1", "geometry"
     )
   )
   expect_equal(
     names(clean_names(test_df, "big_camel")),
     c(
-      "SpAce", "Repeated", "A", "Percent", "X", "X_2", "D9", "Repeated_2",
-      "Cant", "HiThere", "LeadingSpaces", "X_3", "Acao", "Faroe", "ABCDEF", "TestCamelCase", "Leadingpunct", "AverageNumberOfDays", "Jan2009Sales", "Jan2009Sales_2", "geometry"
+      "SpAce", "Repeated", "A", "Percent", "X", "X_1", "D9", "Repeated_1",
+      "Cant", "HiThere", "LeadingSpaces", "X_2", "Acao", "Faroe", "ABCDEF", "TestCamelCase", "Leadingpunct", "AverageNumberOfDays", "Jan2009Sales", "Jan2009Sales_1", "geometry"
     )
   )
   expect_equal(
     names(clean_names(test_df, "all_caps")),
     c(
-      "SP_ACE", "REPEATED", "A", "PERCENT", "X", "X_2", "D_9", "REPEATED_2",
-      "CANT", "HI_THERE", "LEADING_SPACES", "X_3", "ACAO", "FAROE", "A_B_C_D_E_F", "TEST_CAMEL_CASE", "LEADINGPUNCT", "AVERAGE_NUMBER_OF_DAYS", "JAN2009SALES", "JAN_2009_SALES", "geometry"
+      "SP_ACE", "REPEATED", "A", "PERCENT", "X", "X_1", "D_9", "REPEATED_1",
+      "CANT", "HI_THERE", "LEADING_SPACES", "X_2", "ACAO", "FAROE", "A_B_C_D_E_F", "TEST_CAMEL_CASE", "LEADINGPUNCT", "AVERAGE_NUMBER_OF_DAYS", "JAN2009SALES", "JAN_2009_SALES", "geometry"
     )
   )
   expect_equal(
     names(clean_names(test_df, "lower_upper")),
     c(
-      "spACE", "repeated", "a", "percent", "x", "x_2", "d9", "repeated_2",
-      "cant", "hiTHERE", "leadingSPACES", "x_3", "acao", "faroe", "aBcDeF", "testCAMELcase", "leadingpunct", "averageNUMBERofDAYS", "jan2009SALES", "jan2009SALES_2", "geometry"
+      "spACE", "repeated", "a", "percent", "x", "x_1", "d9", "repeated_1",
+      "cant", "hiTHERE", "leadingSPACES", "x_2", "acao", "faroe", "aBcDeF", "testCAMELcase", "leadingpunct", "averageNUMBERofDAYS", "jan2009SALES", "jan2009SALES_1", "geometry"
     )
   )
   expect_equal(
     names(clean_names(test_df, "upper_lower")),
     c(
-      "SPace", "REPEATED", "A", "PERCENT", "X", "X_2", "D9", "REPEATED_2",
-      "CANT", "HIthere", "LEADINGspaces", "X_3", "ACAO", "FAROE", "AbCdEf", "TESTcamelCASE", "LEADINGPUNCT", "AVERAGEnumberOFdays", "JAN2009sales", "JAN2009sales_2", "geometry"
+      "SPace", "REPEATED", "A", "PERCENT", "X", "X_1", "D9", "REPEATED_1",
+      "CANT", "HIthere", "LEADINGspaces", "X_2", "ACAO", "FAROE", "AbCdEf", "TESTcamelCASE", "LEADINGPUNCT", "AVERAGEnumberOFdays", "JAN2009sales", "JAN2009sales_1", "geometry"
     )
   )
   expect_equal(
     names(clean_names(test_df, "none")),
     c(
-      "sp_ace", "repeated", "a", "percent", "X", "X_2", "d_9", "REPEATED",
-      "cant", "hi_there", "leading_spaces", "X_3", "acao", "Faroe", "a_b_c_d_e_f", 
+      "sp_ace", "repeated", "a", "percent", "X", "X_1", "d_9", "REPEATED",
+      "cant", "hi_there", "leading_spaces", "X_2", "acao", "Faroe", "a_b_c_d_e_f", 
       "testCamelCase", "leadingpunct", "average_number_of_days", 
       "jan2009sales", "jan_2009_sales", "geometry"
     )
@@ -570,13 +577,13 @@ test_that("tbl_graph/tidygraph", {
   expect_equal(clean[3], "a") # multiple special chars, trailing special chars
   expect_equal(clean[4], "percent") # converting % to percent
   expect_equal(clean[5], "x") # 100% invalid name
-  expect_equal(clean[6], "x_2") # repeat of invalid name
+  expect_equal(clean[6], "x_1") # repeat of invalid name
   expect_equal(clean[7], "d_9") # multiple special characters
-  expect_equal(clean[8], "repeated_2") # uppercase, 2nd instance of repeat
+  expect_equal(clean[8], "repeated_1") # uppercase, 2nd instance of repeat
   expect_equal(clean[9], "cant") # uppercase, 2nd instance of repeat
   expect_equal(clean[10], "hi_there") # double-underscores to single
   expect_equal(clean[11], "leading_spaces") # leading spaces
-  expect_equal(clean[12], "x_3") # euro sign, invalid
+  expect_equal(clean[12], "x_2") # euro sign, invalid
   expect_equal(clean[13], "acao") # accented word, transliterated to latin,
   expect_equal(clean[14], "faroe") # œ character was failing to convert on Windows, should work universally for stringi 1.1.6 or higher
   # https://github.com/sfirke/janitor/issues/120#issuecomment-303385418

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -188,6 +188,13 @@ test_that("do not create duplicates (fix #251)", {
   )
 })
 
+test_that("allow for duplicates (fix #495)", {
+  expect_equal(
+    make_clean_names(c("a", "a", "a_2"), allow_dupes = TRUE),
+    c("a", "a", "a_2")
+  )
+})
+
 test_that("warnings are issued when micro/mu are not handled (fix #448)", {
   # Warning due to partially handled mu
   expect_warning(expect_equal(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds an `allow_dupes` parameter to `make_clean_names()` -- defaults to `FALSE`.

## Related Issue
<!--- Please note what issue(s) your pull request addresses,
e.g., "fixes #150".  If there's not an issue related to your
pull request, please create one so we can align on the problem
being addressed. -->
Fixes #495 