### PR TITLE
Use `all_of()` to select with external variable

### DIFF
--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -132,7 +132,7 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "T
     if ("col" %in% where) {
       # Add totals col
       row_totals <- dat %>%
-        dplyr::select(cols_to_total) %>%
+        dplyr::select(dplyr::all_of(cols_to_total)) %>%
         dplyr::select_if(is.numeric) %>%
         dplyr::transmute(Total = rowSums(., na.rm = na.rm))
       


### PR DESCRIPTION
Fixes this tidyselect warning:

```r
Warning (test-adorn_totals.R:47): row and column names are taken correctly from a vector
Using an external vector in selections was deprecated in tidyselect 1.1.0.
ℹ Please use `all_of()` or `any_of()` instead.
  # Was:
  data %>% select(cols_to_total)

  # Now:
  data %>% select(all_of(cols_to_total))
```