### PR TITLE
use getOption("OutDec") as decimal separator, fix #451

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,9 +27,10 @@
 ## Minor features
 
 * Some warning messages now have classes so that they can be specifically suppressed with suppressWarnings(..., class="the_class_to_suppress").  To find the class of a warning you typically must look at the code where the error is occurring.  (#452, thanks to **@mgacc0** for suggesting and **@billdenney** for fixing)
-* `excel_numeric_to_date()` now warns when times are converted to `NA` due to hours that do not exist because of daylight savings time (fix #420, thanks **@Geomorph2** for reporting and **@billdenney** for fixing).  It also warns when inputs are not positive, since Excel only supports values down to 1 (#423).
 
 * `make_clean_names()` (and therefore `clean_names()`) issues a warning if the mu or micro symbol is in the names and it is not or may not be handled by a `replace` argument value.  (#448, thanks **@IndrajeetPatil** for reporting and **@billdenney** for fixing)  The rationale is that standard transliteration would convert "[mu]g" to "mg" when it would be more typically be converted to "ug" for use as a unit.  A new, unexported constant (janitor:::mu_to_u) was added to help with mu to "u" replacements.
+
+* `excel_numeric_to_date()` now warns when times are converted to `NA` due to hours that do not exist because of daylight savings time (fix #420, thanks **@Geomorph2** for reporting and **@billdenney** for fixing).  It also warns when inputs are not positive, since Excel only supports values down to 1 (#423).
 
 
 * If a `tabyl()` or similar data.frame is sorted (e.g., with `dplyr::arrange()`), then has `adorn_totals()` and/or `adorn_percentages()` called on it, followed by `adorn_ns()`, the Ns will be sorted correctly to match the tabyl they're being adorned on. (fix #407)
@@ -37,6 +38,8 @@
 * `clean_names()` now supports all object types that have either names or dimnames (#481, @DanChaltiel).
 
 * `make_clean_names()` allows duplicate names to be returned by specifying `unique_sep = NULL` (#495, @JasonAizkalns).
+
+* `adorn_pct_formatting()` uses the locale-dependent value of `decimal.mark` as a decimal separator, e.g., in locales where `getOption("OutDec")` is `,` it will print percentages in the format `"12,34%"` (#451).
 
 ## Bug fixes
 

--- a/R/adorn_pct_formatting.R
+++ b/R/adorn_pct_formatting.R
@@ -2,6 +2,8 @@
 #'
 #' @description
 #' Numeric columns get multiplied by 100 and formatted as percentages according to user specifications.  This function defaults to excluding the first column of the input data.frame, assuming that it contains a descriptive variable, but this can be overridden by specifying the columns to adorn in the \code{...} argument.  Non-numeric columns are always excluded.
+#' 
+#' The decimal separator character is the result of \code{getOption("OutDec")}, which based on the user's locale.  If this isn't desired, change this value ahead of calling the function.
 #'
 #' @param dat a data.frame with decimal values, typically the result of a call to \code{adorn_percentages} on a \code{tabyl}.  If given a list of data.frames, this function will apply itself to each data.frame in the list (designed for 3-way \code{tabyl} lists).
 #' @param digits how many digits should be displayed after the decimal point?
@@ -73,7 +75,10 @@ adorn_pct_formatting <- function(dat, digits = 1, rounding = "half to even", aff
 
     dat[cols_to_adorn] <- lapply(dat[cols_to_adorn], function(x) x * 100)
     dat <- adorn_rounding(dat, digits = digits, rounding = rounding, ...)
-    dat[cols_to_adorn] <- lapply(dat[cols_to_adorn], function(x) format(x, nsmall = digits, trim = TRUE)) # so that 0% prints as 0.0% or 0.00% etc.
+    dat[cols_to_adorn] <- lapply(dat[cols_to_adorn], function(x) format(x,
+                                                                        nsmall = digits,
+                                                                        decimal.mark = getOption("OutDec"),
+                                                                        trim = TRUE)) # so that 0% prints as 0.0% or 0.00% etc.
     if (affix_sign) {
       dat[cols_to_adorn] <- lapply(dat[cols_to_adorn], function(x) paste0(x, "%"))
     }

--- a/man/adorn_pct_formatting.Rd
+++ b/man/adorn_pct_formatting.Rd
@@ -28,6 +28,8 @@ a data.frame with formatted percentages
 }
 \description{
 Numeric columns get multiplied by 100 and formatted as percentages according to user specifications.  This function defaults to excluding the first column of the input data.frame, assuming that it contains a descriptive variable, but this can be overridden by specifying the columns to adorn in the \code{...} argument.  Non-numeric columns are always excluded.
+
+The decimal separator character is the result of \code{getOption("OutDec")}, which based on the user's locale.  If this isn't desired, change this value ahead of calling the function.
 }
 \examples{
 

--- a/tests/testthat/test-adorn-pct-formatting.R
+++ b/tests/testthat/test-adorn-pct-formatting.R
@@ -184,3 +184,13 @@ test_that("tidyselecting works", {
     ignore_attr = TRUE
   )
 })
+
+test_that("decimal.mark works", {
+  locale_decimal_sep <- getOption("OutDec") # not sure if it's necessary to save and restore this,
+  # but seems safe for locale-independent testing processes 
+  options(OutDec= ",") 
+  expect_true(
+    all(grepl(",", unlist(adorn_pct_formatting(source1)[2])))
+  )
+  options(OutDec= locale_decimal_sep)
+})


### PR DESCRIPTION
## Description
Use the locale-specific value of `getOption("OutDec")` in `adorn_pct_formatting`, e.g., creates `"12.34%"
`
## Related Issue
fixed #451 