### PR TITLE
Bug fix: single-column data frame input for `row_to_names()` now works

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,16 @@
 # janitor 2.2.0.9000 - unreleased development version
 
+## Breaking changes
+
+These are all minor breaking changes resulting from enhancements and are not expected to affect the vast majority of users.
+
+* When using `row_to_names()`, when all input values in `row_number` for a column are `NA`, `row_to_names()` creates a column name of `"NA"`, a character, rather than `NA`. If code previously used relied on a column name of `NA`, it will now error. To fix this, rely on a column name of `"NA"`.
+
 ## New features
 
 * A new function `paste_skip_na()` pastes without including NA values (#537).
+
+* `row_to_names()` now accepts multiple rows as input, and merges them using a new `sep` argument (#536). The default is `sep = "_"`. When handling multiple `NA` values, `row_to_names()` ignores them and only merges non-NA values for column names. When all values are `NA`, `row_to_names()` creates a column name of `"NA"`, a character, rather than `NA`.
 
 ## Bug fixes
 

--- a/R/row_to_names.R
+++ b/R/row_to_names.R
@@ -53,7 +53,7 @@ row_to_names <- function(dat, row_number, ..., remove_row = TRUE, remove_rows_ab
   if (is.na(sep)) {
     stop("`sep` can't be of type `NA_character_`.")
   }
-  new_names <- sapply(dat[row_number, ], paste_skip_na, collapse = sep) %>% 
+  new_names <- sapply(dat[row_number, , drop = FALSE], paste_skip_na, collapse = sep) %>% 
     stringr::str_replace_na()
   
   if (any(duplicated(new_names))) {

--- a/R/row_to_names.R
+++ b/R/row_to_names.R
@@ -1,9 +1,10 @@
 #' Elevate a row to be the column names of a data.frame.
 #'
 #' @param dat The input data.frame
-#' @param row_number The row of \code{dat} containing the variable names or the
+#' @param row_number The row(s) of \code{dat} containing the variable names or the
 #'   string \code{"find_header"} to use \code{find_header(dat=dat, ...)} to find
-#'   the row_number.
+#'   the row_number. Allows for multiple rows input as a numeric vector. NA's are
+#'   ignored, and if a column contains only NA value it will be named \code{"NA"}.
 #' @param ... Sent to \code{find_header()}, if
 #'   \code{row_number = "find_header"}.  Otherwise, ignored.
 #' @param remove_row Should the row \code{row_number} be removed from the

--- a/man/row_to_names.Rd
+++ b/man/row_to_names.Rd
@@ -16,9 +16,10 @@ row_to_names(
 \arguments{
 \item{dat}{The input data.frame}
 
-\item{row_number}{The row of \code{dat} containing the variable names or the
+\item{row_number}{The row(s) of \code{dat} containing the variable names or the
 string \code{"find_header"} to use \code{find_header(dat=dat, ...)} to find
-the row_number.}
+the row_number. Allows for multiple rows input as a numeric vector. NA's are
+ignored, and if a column contains only NA value it will be named \code{"NA"}.}
 
 \item{...}{Sent to \code{find_header()}, if
 \code{row_number = "find_header"}.  Otherwise, ignored.}

--- a/tests/testthat/test-row-to-names.R
+++ b/tests/testthat/test-row-to-names.R
@@ -296,5 +296,13 @@ test_that("multiple rows input works", {
       names(),
     "Title_1_2_3",
   )
+  
+  expect_equal(
+    suppressWarnings(
+      row_to_names(df_multiple_na, row_number=c(1,8,9), remove_rows_above = FALSE) %>% 
+        names()
+    ),
+    c("NA", "NA")
+  )
 
 })

--- a/tests/testthat/test-row-to-names.R
+++ b/tests/testthat/test-row-to-names.R
@@ -253,6 +253,7 @@ test_that("multiple rows input works", {
   
   df_multiple_na <- example_data_row_to_names[[1]]
   df_multiple_na[6:7, ] <- NA
+  df_multiple_na[8:9, ] <- ""
   
   expect_equal(
     suppressWarnings(
@@ -290,4 +291,10 @@ test_that("multiple rows input works", {
     c("NA", "NA")
   )
   
+  expect_equal(
+    row_to_names(example_data_row_to_names[[1]][ , 1, drop = FALSE], row_number=1:5) %>% 
+      names(),
+    "Title_1_2_3",
+  )
+
 })

--- a/tests/testthat/test-row-to-names.R
+++ b/tests/testthat/test-row-to-names.R
@@ -285,21 +285,21 @@ test_that("multiple rows input works", {
   
   expect_equal(
     suppressWarnings(
-      row_to_names(df_multiple_na, row_number=c(1,6,7), remove_rows_above = FALSE) %>% 
+      row_to_names(df_multiple_na, row_number=c(1,6,7), remove_rows_above=FALSE) %>% 
         names()
     ),
     c("NA", "NA")
   )
   
   expect_equal(
-    row_to_names(example_data_row_to_names[[1]][ , 1, drop = FALSE], row_number=1:5) %>% 
+    row_to_names(example_data_row_to_names[[1]][,1,drop = FALSE], row_number=1:5) %>% 
       names(),
     "Title_1_2_3",
   )
   
   expect_equal(
     suppressWarnings(
-      row_to_names(df_multiple_na, row_number=c(1,8,9), remove_rows_above = FALSE) %>% 
+      row_to_names(df_multiple_na, row_number=c(1,8,9), remove_rows_above=FALSE) %>% 
         names()
     ),
     c("NA", "NA")

--- a/tests/testthat/test-row-to-names.R
+++ b/tests/testthat/test-row-to-names.R
@@ -294,7 +294,7 @@ test_that("multiple rows input works", {
   expect_equal(
     row_to_names(example_data_row_to_names[[1]][,1,drop = FALSE], row_number=1:5) %>% 
       names(),
-    "Title_1_2_3",
+    "Title_1_2_3"
   )
   
   expect_equal(

--- a/tests/testthat/test-row-to-names.R
+++ b/tests/testthat/test-row-to-names.R
@@ -253,7 +253,7 @@ test_that("multiple rows input works", {
   
   df_multiple_na <- example_data_row_to_names[[1]]
   df_multiple_na[6:7, ] <- NA
-  df_multiple_na[8:9, ] <- ""
+  df_multiple_na[8:10, ] <- ""
   
   expect_equal(
     suppressWarnings(
@@ -299,10 +299,10 @@ test_that("multiple rows input works", {
   
   expect_equal(
     suppressWarnings(
-      row_to_names(df_multiple_na, row_number=c(1,8,9), remove_rows_above=FALSE) %>% 
+      row_to_names(df_multiple_na, row_number=c(8:10), remove_rows_above=FALSE) %>% 
         names()
     ),
-    c("NA", "NA")
+    c("__", "__")
   )
 
 })


### PR DESCRIPTION
## Description
Before this PR and after merging #542, code like this would error:
```
library(janitor)
df <- data.frame(x = c("", "", "", "1"))

df |>
  row_to_names(1:3) |> 
  names()
```

this is because in the code:
```
new_names <- sapply(dat[row_number,], paste_skip_na, collapse = sep) %>% 
    stringr::str_replace_na()
```
the specific call `dat[row_number,]` turns the single-column data frame (i.e., a list of length 1) to a character vector (of length 3 in this case). This, in turn, makes `sapply()` to iterate over a wrong vector and therefore error.

Changing this to `dat[row_number, , drop = FALSE]` solves this.

A relevant test was added to prevent this in the future.

Finally, documentation for the changed behavior of the `row_number` argument in `row_to_names()` was added, and the NEWS file was edited to reflect changes in this PR and in #542.

## Related Issue
Fixes #536 and follows up on #542.

## Example
See above.