### PR TITLE
Remove most superseded dplyr functions

### DIFF
--- a/R/adorn_ns.R
+++ b/R/adorn_ns.R
@@ -95,14 +95,15 @@ adorn_ns <- function(dat, position = "rear", ns = attr(dat, "core"), format_func
     
     if (position == "rear") {
       result <- paste_matrices(dat, ns %>%
-                                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), as.character) %>%
-                                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), wrap_parens) %>%
-                                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), standardize_col_width))
+                                 dplyr::mutate(
+                                   dplyr::across(dplyr::everything(), purrr::compose(as.character, wrap_parens, standardize_col_width, .dir = "forward"))
+                                   ))
     } else if (position == "front") {
       result <- paste_matrices(ns, dat %>%
-                                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), as.character) %>%
-                                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), wrap_parens) %>%
-                                 dplyr::mutate_at(dplyr::vars(-dplyr::group_cols()), standardize_col_width))
+                                 dplyr::mutate(
+                                   dplyr::across(dplyr::everything(), purrr::compose(as.character, wrap_parens, standardize_col_width, .dir = "forward"))
+                                 )
+                                 )
     }
     attributes(result) <- attrs
     

--- a/R/adorn_totals.R
+++ b/R/adorn_totals.R
@@ -143,8 +143,7 @@ adorn_totals <- function(dat, where = "row", fill = "-", na.rm = TRUE, name = "T
     if ("col" %in% where) {
       # Add totals col
       row_totals <- dat %>%
-        dplyr::select(dplyr::all_of(cols_to_total)) %>%
-        dplyr::select_if(is.numeric) %>%
+        dplyr::select(dplyr::all_of(cols_to_total) & dplyr::where(is.numeric)) %>%
         dplyr::transmute(Total = rowSums(., na.rm = na.rm))
       
       dat[[name[2]]] <- row_totals$Total

--- a/R/remove_empties.R
+++ b/R/remove_empties.R
@@ -27,7 +27,7 @@
 #' dd %>% remove_empty("rows")
 #' # solution: preprocess to convert whitespace/empty strings to NA,
 #' # _then_ remove empty (all-NA) rows
-#' dd %>% mutate(across(is.character,~na_if(trimws(.),""))) %>%
+#' dd %>% mutate(across(where(is.character),~na_if(trimws(.),""))) %>%
 #'    remove_empty("rows")
 #' @export
 remove_empty <- function(dat, which = c("rows", "cols"), cutoff=1, quiet=TRUE) {
@@ -93,7 +93,7 @@ remove_empty <- function(dat, which = c("rows", "cols"), cutoff=1, quiet=TRUE) {
 #'
 #' # To find the columns that are constant
 #' data.frame(A=1, B=1:3) %>%
-#'   dplyr::select_at(setdiff(names(.), names(remove_constant(.)))) %>%
+#'   dplyr::select(!dplyr::all_of(names(remove_constant(.)))) %>%
 #'   unique()
 #' @importFrom stats na.omit
 #' @family remove functions

--- a/man/remove_constant.Rd
+++ b/man/remove_constant.Rd
@@ -24,7 +24,7 @@ remove_constant(data.frame(A=1, B=1:3))
 
 # To find the columns that are constant
 data.frame(A=1, B=1:3) \%>\%
-  dplyr::select_at(setdiff(names(.), names(remove_constant(.)))) \%>\%
+  dplyr::select(!dplyr::all_of(names(remove_constant(.)))) \%>\%
   unique()
 }
 \seealso{

--- a/man/remove_empty.Rd
+++ b/man/remove_empty.Rd
@@ -38,7 +38,7 @@ dd <- tibble(x=c(LETTERS[1:5],NA,rep("",2)),
 dd \%>\% remove_empty("rows")
 # solution: preprocess to convert whitespace/empty strings to NA,
 # _then_ remove empty (all-NA) rows
-dd \%>\% mutate(across(is.character,~na_if(trimws(.),""))) \%>\%
+dd \%>\% mutate(across(where(is.character),~na_if(trimws(.),""))) \%>\%
    remove_empty("rows")
 }
 \seealso{

--- a/tests/testthat/test-clean-names.R
+++ b/tests/testthat/test-clean-names.R
@@ -589,7 +589,7 @@ test_that("tbl_graph/tidygraph", {
     tidygraph::play_erdos_renyi(10, 0.5) %>%
     # create nodes wi
     tidygraph::bind_nodes(test_df) %>%
-    tidygraph::mutate_all(tidyr::replace_na, 1)
+    dplyr::mutate(dplyr::across(dplyr::where(is.numeric), ~ dplyr::coalesce(x, 1)))
 
   # create a graph with clean names
   # warning due to unhandled mu


### PR DESCRIPTION
I removed the *_at, *_if, *_all functions from code and examples.

I replaced the example with another syntax.

For the tidygraph test, I did the change so that types are not coerced under the hood. Let me know if you think it is incorrect
`dplyr::mutate(dplyr::across(dplyr::where(is.numeric), ~ dplyr::coalesce(x, 1)))`

I can review.

Thanks for the great package!

A suggestion: maybe the package code could be restyled with styler to follow the tidyverse style guide! I'd be happy to contribute another PR if you think it's a good idea
