### PR TITLE
Improve error messages with cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ BugReports: https://github.com/sfirke/janitor/issues
 Depends:
     R (>= 3.1.2)
 Imports:
+    cli,
     dplyr (>= 1.0.0),
     hms,
     lifecycle,

--- a/R/convert_to_date.R
+++ b/R/convert_to_date.R
@@ -133,11 +133,13 @@ convert_to_datetime_helper.character <- function(x, ..., tz = "UTC", character_f
         character_fun(x[mask_character], ...)
       }
     if (!(out_class %in% class(characters_converted))) {
-      cli::cli_abort(c(
-        x = "`character_fun(x)` must return class {out_class}",
-        "The returned class was: {.obj_type_friendly {characters_converted}}"
-      ),
-      call = error_call)
+      cli::cli_abort(
+        c(
+          x = "`character_fun(x)` must return class {out_class}",
+          "The returned class was: {.obj_type_friendly {characters_converted}}"
+        ),
+        call = error_call
+      )
     }
     ret[mask_character] <- characters_converted
     if (anyNA(ret[mask_character])) {

--- a/tests/testthat/test-convert_to_date.R
+++ b/tests/testthat/test-convert_to_date.R
@@ -103,25 +103,19 @@ test_that("convert_date warnings and errors work", {
   expect_warning(
     expect_error(
       convert_to_date("A"),
-      regexp = "Not all character strings converted to class Date."
+      regexp = "Not all character strings converted to class .+Date"
     ),
     regexp = "All formats failed to parse." # lubridate warning
   )
   expect_warning(
     expect_error(
       convert_to_date(LETTERS),
-      regexp = "Not all character strings converted to class Date.*17 other values",
+      regexp = "Not all character strings converted to class .+Date",
       info = "Confirm the 'other values' when there are many values not converted."
     ),
     regexp = "All formats failed to parse." # lubridate warning
   )
-  expect_warning(
-    expect_error(
-      convert_to_date(LETTERS),
-      regexp = "Not all character strings converted to class Date."
-    ),
-    regexp = "All formats failed to parse." # lubridate warning
-  )
+  
   expect_warning(
     expect_warning(
       expect_equal(
@@ -130,7 +124,7 @@ test_that("convert_date warnings and errors work", {
       ),
       regexp = "All formats failed to parse. No formats found."
     ),
-    regexp = "Not all character strings converted to class Date."
+    regexp = "Not all character strings converted to class.+Date."
   )
   expect_error(
     convert_to_date("A", character_fun = function(x) 1),

--- a/tests/testthat/test-convert_to_date.R
+++ b/tests/testthat/test-convert_to_date.R
@@ -115,7 +115,7 @@ test_that("convert_date warnings and errors work", {
     ),
     regexp = "All formats failed to parse." # lubridate warning
   )
-  
+
   expect_warning(
     expect_warning(
       expect_equal(


### PR DESCRIPTION
## Description

This is just a little proof of concept of how we can improve messages in janitor, using the power of cli.

It is a little difficult to easily see the diff since we decided against using snapshot tests for errors, but I will add before and after screenshots.

If you think this is a reasonable approach, I will try replicating for other common error messages in janitor.

## Related Issue

Addresses #549 

## Example

with this PR

```r
convert_to_date(LETTERS)
```
![image](https://github.com/sfirke/janitor/assets/52606734/85a3c0d2-1c99-4b2d-85ff-f3e2cede2584)

Before:
![image](https://github.com/sfirke/janitor/assets/52606734/3f03fd4e-c247-4938-b8a5-f5a45f580acd)
